### PR TITLE
Fix build failure caused by stray Ok::<(), expression in mount_crypto_subvolumes

### DIFF
--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -356,7 +356,6 @@ impl Installer {
         }
         self.cmd.run("mount", &[&boot_device, &boot_mount])?;
         
-        Ok::<(),
         // Format and mount EFI partition
         let efi_part = layout
             .partitions


### PR DESCRIPTION
A broken turbofish expression `Ok::<(),` was left on line 359 of installer.rs,
which caused 16 cascading parse errors preventing compilation. Removed the
erroneous fragment to restore the intended control flow.

https://claude.ai/code/session_01PQAXWbs8phVRcEpqLTTpPx