### PR TITLE
Fix btrfs subvolume creation conflict with separate boot partition

### DIFF
--- a/src/disk/layouts.rs
+++ b/src/disk/layouts.rs
@@ -459,11 +459,6 @@ pub fn default_subvolumes() -> Vec<SubvolumeDef> {
             mount_point: "/home".to_string(),
             mount_options: "defaults,noatime,compress=zstd".to_string(),
         },
-        SubvolumeDef {
-            name: "@boot".to_string(),
-            mount_point: "/boot".to_string(),
-            mount_options: "defaults,noatime".to_string(),
-        },
     ]
 }
 

--- a/src/install/fstab.rs
+++ b/src/install/fstab.rs
@@ -97,6 +97,7 @@ pub fn generate_fstab_with_fstabgen(
 pub fn generate_fstab_crypto_subvolume(
     cmd: &CommandRunner,
     mapped_device: &str,
+    boot_device: &str,
     efi_device: &str,
     subvolumes: &[SubvolumeDef],
     install_root: &str,
@@ -112,11 +113,13 @@ pub fn generate_fstab_crypto_subvolume(
                 if sv.mount_point == "/" { 1 } else { 0 }
             );
         }
+        println!("    UUID=<BOOT_UUID> /boot btrfs defaults,noatime 0 2");
         println!("    UUID=<EFI_UUID> /boot/efi vfat umask=0077,defaults 0 2");
         return Ok(());
     }
 
     let btrfs_uuid = get_partition_uuid(mapped_device)?;
+    let boot_uuid = get_partition_uuid(boot_device)?;
     let efi_uuid = get_partition_uuid(efi_device)?;
 
     let mut content = String::from(
@@ -139,6 +142,13 @@ pub fn generate_fstab_crypto_subvolume(
             pass,
         ));
     }
+
+    // Add boot partition entry
+    content.push_str(&format!(
+        "\n# Boot partition\n\
+         UUID={}  /boot  btrfs  defaults,noatime  0  2\n",
+        boot_uuid
+    ));
 
     // Add EFI entry
     content.push_str(&format!(


### PR DESCRIPTION
The @boot subvolume was defined inside the LUKS container but /boot is
a separate physical partition in the CryptoSubvolume layout. This caused
the subvolume mount to be overwritten by the partition mount, and the
fstab to reference the wrong device UUID for /boot.

Remove the @boot subvolume from default_subvolumes() and add the boot
partition as a proper entry in generate_fstab_crypto_subvolume().

https://claude.ai/code/session_011ABxsogmrsr65BxFAfwUaz