### PR TITLE
Add lvm2 device-mapper package for mkinitcpio support

### DIFF
--- a/src/configure/mkinitcpio.rs
+++ b/src/configure/mkinitcpio.rs
@@ -46,6 +46,11 @@ pub fn construct_hooks(config: &DeploymentConfig) -> Vec<String> {
         "consolefont".to_string(),
     ]);
 
+    // lvm2 hook provides device-mapper support required by encryption hooks
+    if config.disk.encryption {
+        hooks.push("lvm2".to_string());
+    }
+
     // For CryptoSubvolume layout, use custom hooks
     if config.disk.layout == PartitionLayout::CryptoSubvolume && config.disk.encryption {
         // Custom hooks handle encryption and mounting

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -104,6 +104,8 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
     // Encryption tools (if enabled)
     if config.disk.encryption {
         packages.push("cryptsetup".to_string());
+        // lvm2 provides device-mapper, required by mkinitcpio encrypt/lvm2 hooks
+        packages.push("lvm2".to_string());
     }
 
     packages


### PR DESCRIPTION
The lvm2 package provides device-mapper userspace tools required by
mkinitcpio's encryption hooks (encrypt, crypttab-unlock). Without it,
initramfs generation fails to include device-mapper support needed for
/dev/mapper/* devices.

- Add lvm2 to basestrap package list when encryption is enabled
- Add lvm2 hook to mkinitcpio HOOKS array before encrypt/custom hooks

https://claude.ai/code/session_01RpEQwxSSDJiTRPB4U5UDda