### PR TITLE
Include /etc/crypttab in mkinitcpio initramfs for LUKS unlock

### DIFF
--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -206,8 +206,7 @@ build() {
     map add_udev_rule \
         '10-dm.rules' \
         '13-dm-disk.rules' \
-        '95-dm-notify.rules' \
-        '/usr/lib/initcpio/udev/11-dm-initramfs.rules'
+        '95-dm-notify.rules'
 
     # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
     add_binary '/usr/lib/libgcc_s.so.1'

--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -206,13 +206,17 @@ build() {
     map add_udev_rule \
         '10-dm.rules' \
         '13-dm-disk.rules' \
-        '95-dm-notify.rules'
+        '95-dm-notify.rules' \
+        '/usr/lib/initcpio/udev/11-dm-initramfs.rules'
 
     # cryptsetup calls pthread_create(), which dlopen()s libgcc_s.so.1
     add_binary '/usr/lib/libgcc_s.so.1'
 
     # cryptsetup loads the legacy provider which is required for whirlpool
     add_binary '/usr/lib/ossl-modules/legacy.so'
+
+    # Include /etc/crypttab so the hook can read it at boot
+    add_file '/etc/crypttab'
 
     add_runscript
 }

--- a/src/configure/mkinitcpio.rs
+++ b/src/configure/mkinitcpio.rs
@@ -96,13 +96,18 @@ pub fn construct_binaries(_config: &DeploymentConfig) -> Vec<String> {
 
 /// Construct FILES array
 pub fn construct_files(config: &DeploymentConfig) -> Vec<String> {
-    let files = Vec::new();
+    let mut files = Vec::new();
+
+    // Include /etc/crypttab in the initramfs so the crypttab-unlock hook can
+    // parse it at early boot and open LUKS containers.
+    if config.disk.encryption && config.disk.layout == PartitionLayout::CryptoSubvolume {
+        files.push("/etc/crypttab".to_string());
+    }
 
     // TODO: Add keyfile for encryption if needed
     // if config.disk.encryption {
     //     files.push("/crypto_keyfile.bin".to_string());
     // }
-    let _ = config; // Silence unused warning until encryption is implemented
 
     files
 }


### PR DESCRIPTION
The crypttab-unlock hook reads /etc/crypttab at boot to discover and
open LUKS containers, but the file was never being included in the
initramfs image. This caused the hook to silently skip with "No
/etc/crypttab found" and leave containers locked.

- Add `add_file '/etc/crypttab'` to crypttab-unlock install script
- Add /etc/crypttab to mkinitcpio.conf FILES array for CryptoSubvolume
- Sync missing 11-dm-initramfs.rules udev rule from reference script

https://claude.ai/code/session_01H6uvEQA4MNpC9cwkZWGAYE