### PR TITLE
Improve info log output to better reflect ongoing actions

### DIFF
--- a/src/cleanup/mod.rs
+++ b/src/cleanup/mod.rs
@@ -24,7 +24,7 @@ impl Cleaner {
 
     /// Perform cleanup operations
     pub fn cleanup(&self, device: Option<&str>, wipe: bool) -> Result<()> {
-        info!("Starting cleanup");
+        info!("Starting cleanup (unmount, close LUKS{})", if wipe { ", wipe" } else { "" });
 
         // Unmount all filesystems
         self.unmount_all()?;
@@ -43,13 +43,13 @@ impl Cleaner {
             self.wipe_device(&device)?;
         }
 
-        info!("Cleanup complete");
+        info!("Cleanup complete (all resources released)");
         Ok(())
     }
 
     /// Unmount all filesystems under install root
     fn unmount_all(&self) -> Result<()> {
-        info!("Unmounting all filesystems");
+        info!("Unmounting all filesystems under {}", INSTALL_ROOT);
 
         // Disable swap first
         let _ = self.cmd.run("swapoff", &["-a"]);
@@ -82,7 +82,7 @@ impl Cleaner {
 
     /// Close any open LUKS encrypted volumes
     fn close_encrypted_volumes(&self) -> Result<()> {
-        info!("Closing encrypted volumes");
+        info!("Closing any open LUKS encrypted volumes");
 
         // Common mapper names used in the original script
         let mapper_names = [
@@ -144,7 +144,7 @@ impl Cleaner {
             return Err(DeploytixError::UserCancelled);
         }
 
-        info!("Wiping partition table on {}", device);
+        info!("Wiping partition table and filesystem signatures on {}", device);
 
         if self.cmd.is_dry_run() {
             println!("  [dry-run] Would wipe partition table on {}", device);
@@ -177,7 +177,7 @@ impl Cleaner {
             }
         }
 
-        info!("Partition table wiped on {}", device);
+        info!("Partition table wiped and blank GPT created on {}", device);
         Ok(())
     }
 }

--- a/src/configure/bootloader.rs
+++ b/src/configure/bootloader.rs
@@ -44,7 +44,7 @@ fn install_grub(
     device: &str,
     install_root: &str,
 ) -> Result<()> {
-    info!("Installing GRUB bootloader");
+    info!("Installing GRUB bootloader to {} (x86_64-efi)", device);
 
     // Get root partition - find it dynamically based on layout
     let root_partition_num = match config.disk.layout {
@@ -83,7 +83,7 @@ fn install_grub_with_layout(
     layout: &ComputedLayout,
     install_root: &str,
 ) -> Result<()> {
-    info!("Installing GRUB bootloader for encrypted system");
+    info!("Installing GRUB bootloader to {} (x86_64-efi, encrypted)", device);
 
     // Find LUKS partition from layout
     let luks_part = layout.partitions.iter().find(|p| p.is_luks);
@@ -199,7 +199,7 @@ GRUB_CMDLINE_LINUX_DEFAULT="{}"
     fs::create_dir_all(format!("{}/etc/default", install_root))?;
     fs::write(&grub_default_path, content)?;
 
-    info!("GRUB defaults configured");
+    info!("GRUB defaults written to /etc/default/grub");
     Ok(())
 }
 

--- a/src/configure/encryption.rs
+++ b/src/configure/encryption.rs
@@ -44,7 +44,7 @@ pub fn setup_encryption(
     let mapper_name = config.disk.luks_mapper_name.clone();
     let mapped_path = format!("/dev/mapper/{}", mapper_name);
 
-    info!("Setting up LUKS encryption on {}", luks_device);
+    info!("Setting up LUKS2 encryption on {} (mapper: {})", luks_device, mapper_name);
 
     if cmd.is_dry_run() {
         println!("  [dry-run] cryptsetup luksFormat --type luks2 {}", luks_device);
@@ -62,7 +62,7 @@ pub fn setup_encryption(
     // Open LUKS container
     luks_open(&luks_device, &mapper_name, password)?;
 
-    info!("LUKS encryption setup complete: {}", mapped_path);
+    info!("LUKS encryption setup complete: {} -> {}", luks_device, mapped_path);
 
     Ok(LuksContainer {
         device: luks_device,
@@ -73,7 +73,7 @@ pub fn setup_encryption(
 
 /// Format a device as LUKS2
 fn luks_format(device: &str, password: &str) -> Result<()> {
-    info!("Formatting {} as LUKS2 container", device);
+    info!("Formatting {} as LUKS2 container (aes-xts-plain64, argon2id)", device);
 
     // Use stdin to pass password securely (fixes command injection vulnerability)
     let mut child = Command::new("cryptsetup")

--- a/src/configure/greetd.rs
+++ b/src/configure/greetd.rs
@@ -14,11 +14,12 @@ pub fn configure_greetd(
 ) -> Result<()> {
     // Only configure greetd if a desktop environment is selected
     if config.desktop.environment == DesktopEnvironment::None {
-        info!("No desktop environment selected, skipping greetd configuration");
+        info!("Skipping greetd configuration (no desktop environment selected)");
         return Ok(());
     }
 
-    info!("Configuring greetd");
+    info!("Configuring greetd for user '{}' with session '{}'",
+        config.user.name, get_session_command(&config.desktop.environment));
 
     if cmd.is_dry_run() {
         println!("  [dry-run] Would configure /etc/greetd/config.toml");
@@ -48,7 +49,7 @@ user = "{user}"
     fs::create_dir_all(&greetd_dir)?;
     fs::write(format!("{}/config.toml", greetd_dir), config_content)?;
 
-    info!("greetd configured for user: {}", username);
+    info!("greetd config written to /etc/greetd/config.toml for user '{}'", username);
     Ok(())
 }
 

--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -22,9 +22,9 @@ pub fn install_custom_hooks(
     layout: &ComputedLayout,
     install_root: &str,
 ) -> Result<()> {
-    info!("Installing custom mkinitcpio hooks");
-
     let hooks = generate_hooks(config, layout)?;
+    let hook_names: Vec<&str> = hooks.iter().map(|h| h.name.as_str()).collect();
+    info!("Installing {} custom mkinitcpio hooks: [{}]", hooks.len(), hook_names.join(", "));
 
     if cmd.is_dry_run() {
         for hook in &hooks {
@@ -53,7 +53,7 @@ pub fn install_custom_hooks(
         fs::write(&install_path, &hook.install_content)?;
         fs::set_permissions(&install_path, fs::Permissions::from_mode(0o755))?;
 
-        info!("Installed hook: {}", hook.name);
+        info!("Installed hook '{}' to {}", hook.name, hooks_dir);
     }
 
     Ok(())

--- a/src/configure/locale.rs
+++ b/src/configure/locale.rs
@@ -13,7 +13,7 @@ pub fn configure_locale(
     config: &DeploymentConfig,
     install_root: &str,
 ) -> Result<()> {
-    info!("Configuring locale and timezone");
+    info!("Configuring locale, timezone, keymap, and hostname");
 
     // Set timezone
     set_timezone(cmd, &config.system.timezone, install_root)?;

--- a/src/configure/mkinitcpio.rs
+++ b/src/configure/mkinitcpio.rs
@@ -145,9 +145,9 @@ pub fn configure_mkinitcpio(
     config: &DeploymentConfig,
     install_root: &str,
 ) -> Result<()> {
-    info!("Configuring mkinitcpio");
-
     let mkinitcpio_conf = generate_mkinitcpio_conf(config);
+    let hooks = construct_hooks(config);
+    info!("Configuring mkinitcpio with {} hooks: [{}]", hooks.len(), hooks.join(", "));
     let conf_path = format!("{}/etc/mkinitcpio.conf", install_root);
 
     if cmd.is_dry_run() {
@@ -167,7 +167,7 @@ pub fn configure_mkinitcpio(
     // Write new config
     fs::write(&conf_path, mkinitcpio_conf)?;
 
-    info!("mkinitcpio.conf written");
+    info!("mkinitcpio.conf written to {}", conf_path);
     Ok(())
 }
 

--- a/src/configure/network.rs
+++ b/src/configure/network.rs
@@ -12,7 +12,7 @@ pub fn configure_network(
     config: &DeploymentConfig,
     install_root: &str,
 ) -> Result<()> {
-    info!("Configuring network");
+    info!("Configuring network (backend: {}, dns: {})", config.network.backend, config.network.dns);
 
     // Configure network backend
     match config.network.backend {

--- a/src/configure/services.rs
+++ b/src/configure/services.rs
@@ -13,9 +13,8 @@ pub fn enable_services(
     config: &DeploymentConfig,
     install_root: &str,
 ) -> Result<()> {
-    info!("Enabling services for {}", config.system.init);
-
     let services = build_service_list(config);
+    info!("Enabling {} services for {} init system: [{}]", services.len(), config.system.init, services.join(", "));
 
     for service in services {
         enable_service(cmd, &config.system.init, &service, install_root)?;

--- a/src/configure/users.rs
+++ b/src/configure/users.rs
@@ -16,7 +16,7 @@ pub fn create_user(
     let password = &config.user.password;
     let groups = &config.user.groups;
 
-    info!("Creating user: {}", username);
+    info!("Creating user '{}' with groups [{}]", username, groups.join(", "));
 
     if cmd.is_dry_run() {
         println!("  [dry-run] Would create user {} with groups {:?}", username, groups);

--- a/src/disk/formatting.rs
+++ b/src/disk/formatting.rs
@@ -101,7 +101,7 @@ pub fn format_all_partitions(
     layout: &ComputedLayout,
     filesystem: &Filesystem,
 ) -> Result<()> {
-    info!("Formatting all partitions on {}", device);
+    info!("Formatting {} partitions on {} (default fs: {})", layout.partitions.len(), device, filesystem);
 
     for part in &layout.partitions {
         let part_path = partition_path(device, part.number);
@@ -112,7 +112,7 @@ pub fn format_all_partitions(
             format_swap(cmd, &part_path, Some(&part.name))?;
         } else if part.is_luks {
             // LUKS partitions are handled separately by encryption module
-            info!("Skipping LUKS partition {} (handled by encryption module)", part_path);
+            info!("Skipping {} (LUKS partition, formatted by encryption module)", part_path);
         } else if part.is_bios_boot {
             format_boot(cmd, &part_path)?;
         } else {
@@ -191,7 +191,7 @@ pub fn create_btrfs_subvolumes(
     subvolumes: &[SubvolumeDef],
     fs_mount: &str,
 ) -> Result<()> {
-    info!("Creating btrfs subvolumes on {} (mounted at {})", device, fs_mount);
+    info!("Creating {} btrfs subvolumes on {} (mounted at {})", subvolumes.len(), device, fs_mount);
 
     if cmd.is_dry_run() {
         println!("  [dry-run] mount {} {}", device, fs_mount);

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -119,7 +119,7 @@ pub fn run_basestrap(
 ) -> Result<()> {
     let packages = build_package_list(config);
 
-    info!("Installing {} packages with basestrap", packages.len());
+    info!("Installing {} packages with basestrap to {}", packages.len(), install_root);
 
     // Build argument list
     let mut args = vec![install_root];

--- a/src/install/chroot.rs
+++ b/src/install/chroot.rs
@@ -13,7 +13,7 @@ pub fn mount_partitions(
     layout: &ComputedLayout,
     install_root: &str,
 ) -> Result<()> {
-    info!("Mounting partitions to {}", install_root);
+    info!("Mounting {} partitions from {} to {}", layout.partitions.len(), device, install_root);
 
     // Sort partitions by mount point depth (root first, then deeper paths)
     let mut mount_order: Vec<_> = layout

--- a/src/install/fstab.rs
+++ b/src/install/fstab.rs
@@ -16,7 +16,7 @@ pub fn generate_fstab(
     layout: &ComputedLayout,
     install_root: &str,
 ) -> Result<()> {
-    info!("Generating fstab");
+    info!("Generating /etc/fstab for {} partitions on {}", layout.partitions.len(), device);
 
     if cmd.is_dry_run() {
         println!("  [dry-run] Would generate fstab with entries:");
@@ -102,7 +102,7 @@ pub fn generate_fstab_crypto_subvolume(
     subvolumes: &[SubvolumeDef],
     install_root: &str,
 ) -> Result<()> {
-    info!("Generating fstab for encrypted btrfs subvolumes");
+    info!("Generating /etc/fstab for {} encrypted btrfs subvolumes", subvolumes.len());
 
     if cmd.is_dry_run() {
         println!("  [dry-run] Would generate fstab with btrfs subvolumes:");


### PR DESCRIPTION
Add phase numbers [Phase N/6] to installer orchestration steps, include
specific context (device names, filesystem types, partition counts, hook
lists, service names) in info messages across all modules, and replace
vague descriptions with action-oriented messages that show what is
actually happening.

https://claude.ai/code/session_0118pZn4i4k4cY75hFQ34jn2