### PR TITLE
Skip terminal confirmation prompt when installing via GUI

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -276,7 +276,7 @@ impl DeploytixGui {
             let _ = tx.send(InstallMessage::Progress(0.15));
 
             // Run installer
-            let installer = Installer::new(config, dry_run);
+            let installer = Installer::new(config, dry_run).with_skip_confirm(true);
             match installer.run() {
                 Ok(()) => {
                     let _ = tx.send(InstallMessage::Progress(1.0));

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -37,6 +37,8 @@ pub struct Installer {
     luks_boot_container: Option<LuksContainer>,
     /// Keyfiles for automatic unlocking
     keyfiles: Vec<VolumeKeyfile>,
+    /// Skip interactive confirmation prompt (e.g. when GUI already confirmed)
+    skip_confirm: bool,
 }
 
 impl Installer {
@@ -48,7 +50,15 @@ impl Installer {
             luks_containers: Vec::new(),
             luks_boot_container: None,
             keyfiles: Vec::new(),
+            skip_confirm: false,
         }
+    }
+
+    /// Skip the interactive confirmation prompt.
+    /// Use this when confirmation has already been obtained (e.g. via GUI).
+    pub fn with_skip_confirm(mut self, skip: bool) -> Self {
+        self.skip_confirm = skip;
+        self
     }
 
     /// Run the full installation process
@@ -138,7 +148,7 @@ impl Installer {
             self.config.disk.device
         );
 
-        if !self.cmd.is_dry_run() && !warn_confirm(&warning)? {
+        if !self.cmd.is_dry_run() && !self.skip_confirm && !warn_confirm(&warning)? {
             return Err(crate::utils::error::DeploytixError::UserCancelled);
         }
 


### PR DESCRIPTION
The GUI already has its own confirmation checkbox ("I understand and want
to proceed") on the Summary panel. However, the shared Installer::run()
path still called warn_confirm(), which blocks on stdin waiting for the
user to type "yes" in the terminal — making GUI installations hang.

Add a skip_confirm flag to Installer with a builder method, and set it
when launching the installer from the GUI.

https://claude.ai/code/session_01BwHaNUUtnU9eukz7cYFtuw