### PR TITLE
fix: remove rootflags=subvol=@ for CryptoSubvolume layout to fix /new_root transition

### DIFF
--- a/ref/hooks_mountcrypt
+++ b/ref/hooks_mountcrypt
@@ -56,21 +56,29 @@ run_hook() {
         fi
     done
 
-    # **Auto-detect and mount EFI partition**
+    # Auto-detect and mount EFI partition
     mkdir -p "$new_root/boot/efi"
 
-    # Find EFI partition (filesystem vfat, label "EFI" or partition type EF00)
     efi_partition=""
-    for dev in $(blkid -t TYPE=vfat -o device); do
-        if blkid "$dev" | grep -qi 'PARTLABEL="EFI"'; then
-            efi_partition="$dev"
-            break
-        fi
-    done
 
+    # Primary: use udev-provided partlabel symlink (most reliable in initramfs)
+    if [ -b "/dev/disk/by-partlabel/EFI" ]; then
+        efi_partition="/dev/disk/by-partlabel/EFI"
+    fi
+
+    # Fallback: blkid search by PARTLABEL
     if [ -z "$efi_partition" ]; then
-        # Fallback: first vfat partition
-        efi_partition=$(blkid -t TYPE=vfat -o device | head -n1)
+        for dev in $(blkid -t TYPE=vfat -o device 2>/dev/null); do
+            if blkid "$dev" | grep -qi 'PARTLABEL="EFI"'; then
+                efi_partition="$dev"
+                break
+            fi
+        done
+    fi
+
+    # Last resort: first vfat partition
+    if [ -z "$efi_partition" ]; then
+        efi_partition=$(blkid -t TYPE=vfat -o device 2>/dev/null | head -n1)
     fi
 
     if [ -n "$efi_partition" ] && [ -b "$efi_partition" ]; then

--- a/ref/hooks_mountcrypt
+++ b/ref/hooks_mountcrypt
@@ -34,23 +34,22 @@ run_hook() {
 
     mkdir -p "$new_root"
 
-    # Mount primary root subvolume (@)
-    mount -o rw,subvol=@ "$cryptroot" "$new_root" || {
-        echo "Error mounting subvolume '@'" >&2
+    # Mount root (separate LUKS partition, plain btrfs - no subvolumes)
+    mount -o rw "$cryptroot" "$new_root" || {
+        echo "Error mounting root filesystem" >&2
         return 1
     }
 
-    # Mount additional subvolumes
+    # Mount additional encrypted volumes (each is a separate LUKS partition)
     for mp in usr var home boot; do
         target="$new_root/$mp"
-        subvol="@${mp}"
         mapped_device="/dev/mapper/Crypt-$(echo "$mp" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
 
         mkdir -p "$target"
 
         if [ -b "$mapped_device" ]; then
-            mount -o rw,subvol=${subvol} "$mapped_device" "$target" || {
-                echo "Warning: Could not mount $mapped_device (subvolume $subvol) on $target" >&2
+            mount -o rw "$mapped_device" "$target" || {
+                echo "Warning: Could not mount $mapped_device on $target" >&2
             }
         else
             echo "Warning: Mapped device $mapped_device not found, skipping $target" >&2

--- a/src/configure/bootloader.rs
+++ b/src/configure/bootloader.rs
@@ -198,7 +198,11 @@ fn configure_grub_defaults(
         // Encrypted system
         cmdline_parts.push(format!("cryptdevice=UUID={}:{}", root_or_luks_uuid, mapper));
         cmdline_parts.push(format!("root=/dev/mapper/{}", mapper));
-        cmdline_parts.push("rootflags=subvol=@".to_string());
+        // Only add subvol=@ for layouts that use btrfs subvolumes.
+        // CryptoSubvolume uses separate LUKS partitions with plain btrfs (no subvolumes).
+        if config.disk.layout != PartitionLayout::CryptoSubvolume {
+            cmdline_parts.push("rootflags=subvol=@".to_string());
+        }
         cmdline_parts.push("rw".to_string());
     } else {
         // Non-encrypted system


### PR DESCRIPTION
The CryptoSubvolume layout uses separate LUKS partitions with plain btrfs
filesystems (no @ subvolumes), but the kernel cmdline was unconditionally
adding rootflags=subvol=@. This caused switch_root to /new_root to fail
because the kernel expected a subvolume that doesn't exist.

Also updates the reference mountcrypt hook to remove subvol mount options,
matching the actual multi-volume design.

https://claude.ai/code/session_011tWCXXu3bZadNMgVHhGf2N