### PR TITLE
Add boot encryption status to GUI summary panel

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -532,6 +532,7 @@ impl eframe::App for DeploytixGui {
                         &self.partition_layout,
                         &self.filesystem,
                         self.encryption,
+                        self.boot_encryption,
                         self.integrity,
                         &self.swap_type,
                         &self.init_system,

--- a/src/gui/panels.rs
+++ b/src/gui/panels.rs
@@ -461,6 +461,7 @@ pub fn summary_panel(
     layout: &PartitionLayout,
     filesystem: &Filesystem,
     encryption: bool,
+    boot_encryption: bool,
     integrity: bool,
     swap_type: &SwapType,
     init: &InitSystem,
@@ -495,6 +496,16 @@ pub fn summary_panel(
             ui.label("Encryption:");
             ui.label(if encryption { "Enabled" } else { "Disabled" });
             ui.end_row();
+
+            if encryption {
+                ui.label("Boot Encryption:");
+                ui.label(if boot_encryption {
+                    "Enabled (LUKS1)"
+                } else {
+                    "Disabled"
+                });
+                ui.end_row();
+            }
 
             ui.label("Integrity:");
             ui.label(if integrity {


### PR DESCRIPTION
The boot encryption option was present in the disk config panel but
missing from the summary/review panel, so users couldn't verify their
boot encryption choice before starting installation.

https://claude.ai/code/session_01VAhscVRgDCoSTxvCXqaNcs