### PR TITLE
Fix clippy errors, shell injection, and improve error handling

### DIFF
--- a/src/configure/bootloader.rs
+++ b/src/configure/bootloader.rs
@@ -307,6 +307,7 @@ pub fn create_efi_boot_entry(
 ///
 /// This finds the boot entry with the given label and moves it to the front
 /// of the boot order.
+#[allow(dead_code)]
 pub fn set_efi_boot_order_priority(
     cmd: &CommandRunner,
     label: &str,

--- a/src/disk/formatting.rs
+++ b/src/disk/formatting.rs
@@ -145,7 +145,14 @@ pub fn get_partition_uuid(partition: &str) -> Result<String> {
         )));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    let uuid = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if uuid.is_empty() {
+        return Err(DeploytixError::FilesystemError(format!(
+            "blkid returned empty UUID for {}",
+            partition
+        )));
+    }
+    Ok(uuid)
 }
 
 /// Get all partition UUIDs for a layout

--- a/src/install/fstab.rs
+++ b/src/install/fstab.rs
@@ -388,21 +388,32 @@ pub fn generate_fstab_multi_volume(
     Ok(())
 }
 
+/// Parameters for LVM thin fstab generation
+pub struct LvmThinFstabParams<'a> {
+    pub cmd: &'a CommandRunner,
+    pub vg_name: &'a str,
+    pub thin_volumes: &'a [ThinVolumeDef],
+    pub device: &'a str,
+    pub layout: &'a ComputedLayout,
+    pub swap_type: &'a SwapType,
+    pub boot_mapped_device: Option<&'a str>,
+    pub install_root: &'a str,
+}
+
 /// Generate fstab for LVM thin provisioning layout
 ///
 /// Creates entries for thin LVs mounted from /dev/vg/lv paths.
 /// When `boot_mapped_device` is Some, the boot partition is encrypted and
 /// the filesystem UUID should be read from the mapped device path.
-pub fn generate_fstab_lvm_thin(
-    cmd: &CommandRunner,
-    vg_name: &str,
-    thin_volumes: &[ThinVolumeDef],
-    device: &str,
-    layout: &ComputedLayout,
-    swap_type: &SwapType,
-    boot_mapped_device: Option<&str>,
-    install_root: &str,
-) -> Result<()> {
+pub fn generate_fstab_lvm_thin(params: &LvmThinFstabParams) -> Result<()> {
+    let cmd = params.cmd;
+    let vg_name = params.vg_name;
+    let thin_volumes = params.thin_volumes;
+    let device = params.device;
+    let layout = params.layout;
+    let swap_type = params.swap_type;
+    let boot_mapped_device = params.boot_mapped_device;
+    let install_root = params.install_root;
     info!("Generating /etc/fstab for LVM thin volumes");
 
     if cmd.is_dry_run() {

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -20,6 +20,7 @@ use crate::disk::partitioning::apply_partitions;
 use crate::install::crypttab::generate_crypttab_multi_volume;
 use crate::install::fstab::{
     append_swap_file_entry, generate_fstab_lvm_thin, generate_fstab_multi_volume,
+    LvmThinFstabParams,
 };
 use crate::install::{generate_fstab, mount_partitions, run_basestrap, unmount_all};
 use crate::utils::command::CommandRunner;
@@ -923,16 +924,16 @@ impl Installer {
             .as_ref()
             .map(|c| c.mapped_path.as_str());
 
-        generate_fstab_lvm_thin(
-            &self.cmd,
+        generate_fstab_lvm_thin(&LvmThinFstabParams {
+            cmd: &self.cmd,
             vg_name,
-            &self.lvm_thin_volumes,
-            &self.config.disk.device,
+            thin_volumes: &self.lvm_thin_volumes,
+            device: &self.config.disk.device,
             layout,
-            &self.config.disk.swap_type,
-            boot_mapped,
-            INSTALL_ROOT,
-        )
+            swap_type: &self.config.disk.swap_type,
+            boot_mapped_device: boot_mapped,
+            install_root: INSTALL_ROOT,
+        })
     }
 
     /// Generate crypttab for LVM thin layout


### PR DESCRIPTION
- Fix clippy too-many-arguments error in generate_fstab_lvm_thin by
  introducing LvmThinFstabParams struct
- Fix shell command injection in cleanup wipe_device fdisk fallback by
  using piped stdin instead of sh -c with string interpolation
- Add empty UUID validation in get_partition_uuid to catch blkid
  returning empty output before it propagates to fstab/crypttab
- Improve unmount_all to warn on failures and attempt lazy unmount
  instead of silently ignoring errors
- Suppress dead_code warning on set_efi_boot_order_priority

https://claude.ai/code/session_01PgDiN1BZrRhup5WvCi52sG