### PR TITLE
Fix encryption state leaking from LvmThin into Standard layout

### DIFF
--- a/src/gui/panels.rs
+++ b/src/gui/panels.rs
@@ -85,6 +85,7 @@ pub fn disk_config_panel(
     ui.add_space(8.0);
 
     // Partition Layout
+    let prev_layout = layout.clone();
     ui.label("Partition Layout:");
     egui::ComboBox::from_id_salt("layout")
         .selected_text(format!("{}", layout))
@@ -111,6 +112,12 @@ pub fn disk_config_panel(
     if *layout == PartitionLayout::LvmThin {
         *encryption = true;
         *filesystem = Filesystem::Btrfs;
+    }
+
+    // When switching away from LvmThin, clear the encryption state that was
+    // force-enabled by LvmThin so it doesn't bleed into Standard/Minimal.
+    if prev_layout == PartitionLayout::LvmThin && *layout != PartitionLayout::LvmThin {
+        *encryption = false;
     }
 
     // Filesystem


### PR DESCRIPTION
When the user selected LvmThin layout, encryption was forced to true.
Switching back to Standard/Minimal kept encryption=true, causing the
password, integrity, and boot-encryption options to appear unexpectedly —
making the Standard layout look different on first load vs after a
round-trip through LvmThin.

Fix: capture the previous layout before the ComboBox runs and reset
encryption to false when transitioning away from LvmThin.

https://claude.ai/code/session_01Ek1eBCrFLoCmJtsvFcjt3y