### PR TITLE
Add unit tests for pure functions across 6 modules and test coverage proposal

### DIFF
--- a/docs/test-coverage-proposal.md
+++ b/docs/test-coverage-proposal.md
@@ -1,0 +1,239 @@
+# Test Coverage Analysis & Improvement Proposal
+
+## Current State
+
+The codebase has **68 unit tests** spread across **6 files** out of 47 total Rust source files
+(~13% file coverage). The tests that exist are high-quality and focused on critical boot-time
+logic (initramfs hooks, mkinitcpio configuration, LUKS volume management). But large portions of
+the installer are completely untested.
+
+### Files with tests today
+
+| File | Tests | What is covered |
+|------|------:|-----------------|
+| `configure/hooks.rs` | 12 | Custom initramfs hook generation |
+| `configure/mkinitcpio.rs` | 14 | mkinitcpio MODULES/HOOKS/FILES arrays |
+| `disk/volumes.rs` | 6 | VolumeSet construction, encryption, LVM thin |
+| `configure/keyfiles.rs` | 1 | Keyfile path derivation |
+| `configure/encryption.rs` | 5 | `to_title_case` helper *(added in this PR)* |
+| `configure/swap.rs` | 3 | `swap_file_fstab_entry` *(added in this PR)* |
+| `install/crypttab.rs` | 2 | `crypttab_options` *(added in this PR)* |
+| `config/deployment.rs` | 8 | `CustomPartitionEntry`, `InitSystem` *(added in this PR)* |
+| `disk/layouts.rs` | 9 | Math helpers, layout queries *(added in this PR)* |
+| `disk/detection.rs` | 8 | `partition_prefix`, `partition_path` *(added in this PR)* |
+
+---
+
+## Areas to Improve
+
+The sections below are ordered by risk/impact. Each includes the rationale, the specific
+functions that should be tested, and the main challenge to overcome.
+
+---
+
+### 1. `config/deployment.rs` — `DeploymentConfig::validate()`
+
+**Risk: HIGH** — The validation function contains ~15 distinct business rules that prevent
+nonsensical configurations (e.g. boot encryption without base encryption, integrity without
+encryption, duplicate custom mount points). None of these rules have automated tests.
+
+**Problem:** `validate()` checks block device existence as its very first step, which makes
+every subsequent rule unreachable in a unit-test environment that has no real disk.
+
+**Recommended fix:** Extract the pure logical checks into a private `validate_rules()` helper
+that takes only `&self` and returns `Result<()>`. Call it from `validate()` after the device
+check. This allows every business rule to be unit-tested without hardware:
+
+```rust
+// Example: rules that should each have their own test
+fn validate_rules(&self) -> Result<()> {
+    if self.user.name.is_empty() { /* ... */ }
+    if self.disk.integrity && !self.disk.encryption { /* ... */ }
+    if self.disk.boot_encryption && !self.disk.encryption { /* ... */ }
+    if self.disk.lvm_thin_pool_percent == 0 || self.disk.lvm_thin_pool_percent > 100 { /* ... */ }
+    // SecureBoot ManualKeys requires keys_path
+    // Custom layout: root required, no reserved mounts, no duplicates, ≤1 remainder
+    // Subvolumes require btrfs
+    // SwapType::FileZram requires btrfs or ext4
+    Ok(())
+}
+```
+
+---
+
+### 2. `install/fstab.rs` — fstab content generation
+
+**Risk: HIGH** — Incorrect fstab entries cause an unbootable system. The module has five public
+entry-point functions covering regular, subvolume, multi-volume (LUKS), LVM thin, and swap-file
+layouts. None are tested.
+
+**Problem:** All functions call `get_partition_uuid()` which reads from the real filesystem, and
+they write files to disk.
+
+**Recommended fix:** Use the existing `CommandRunner::new(true)` (dry-run mode). In dry-run the
+functions print what they would do but skip I/O. Alternatively, split the string-building logic
+from the I/O so the core formatting can be tested with a mock UUID provider. Key scenarios to
+cover:
+
+- Correct fstab options per partition type (EFI=vfat, root=btrfs pass=1, others pass=2)
+- Swap partition vs. swap file entries
+- Btrfs subvolume `subvol=` option presence
+- Multi-volume LUKS: entries use mapper paths, not raw device paths
+- LVM thin: entries use `/dev/vg/lv` paths
+
+---
+
+### 3. `disk/layouts.rs` — `compute_layout` / `compute_layout_from_config`
+
+**Risk: HIGH** — These functions produce the partition table plan that drives the entire
+installation. Calculation errors lead to mis-sized or missing partitions.
+
+**Problem:** `compute_standard_layout`, `compute_minimal_layout`, and `compute_lvm_thin_layout`
+internally call `get_ram_mib()` which reads `/proc/meminfo`. The public wrappers
+`compute_layout` / `compute_layout_from_config` also accept a `DeploymentConfig` that requires
+device validation.
+
+**Recommended fix:** Export `compute_lvm_thin_layout_with_swap` (already public) and add a
+thin wrapper `compute_layout_for_disk(disk_mib: u64, layout: PartitionLayout)` that can be
+called with synthetic disk sizes. Specific scenarios to verify:
+
+- Standard layout: correct partition count, EFI=512 MiB, BOOT=2048 MiB
+- Minimum disk size enforcement (error on disk smaller than required)
+- `compute_standard_layout` on 256 GiB disk produces swap capped at 20 GiB
+- LVM layout without swap: no SWAP partition, LVM PV is remainder
+- Custom layout: remainder partition gets all space; two remainder partitions → error
+
+---
+
+### 4. `install/crypttab.rs` — `generate_crypttab_multi_volume`
+
+**Risk: HIGH** — crypttab drives automatic volume unlocking at boot. A wrong volume name, UUID
+reference, or option string leaves the system locked. The `generate_crypttab_multi_volume`
+function already has testable string-building logic: it iterates containers and keyfiles to
+assemble lines in a fixed format.
+
+**Problem:** It calls `get_luks_uuid()` per container, which reads real LUKS metadata.
+
+**Recommended fix:** Add a thin abstraction (`UuidProvider` trait or a closure parameter) so
+tests can inject known UUID strings. Key assertions:
+
+- Each container generates exactly one `name UUID=<uuid> keyfile options` line
+- Integrity flag changes options from `luks,discard` to `luks`
+- Boot container (LUKS1) always uses `luks,discard` regardless of integrity flag
+- Missing keyfile falls back to `keyfile_path(volume_name)` derivation
+
+---
+
+### 5. `configure/bootloader.rs` — GRUB config generation
+
+**Risk: MEDIUM-HIGH** — `configure_grub_defaults` and `configure_grub_defaults_lvm_thin` write
+`/etc/default/grub`. A wrong kernel command line (e.g. missing `cryptdevice=` or `rd.luks.name=`)
+prevents unlocking the encrypted root at boot.
+
+**Problem:** Functions write directly to files under `install_root`.
+
+**Recommended fix:** Use `tempfile::tempdir()` as `install_root`. The generated file content can
+then be read back and asserted. Scenarios:
+
+- Encrypted standard: `cryptdevice=` present in `GRUB_CMDLINE_LINUX`
+- Encrypted LVM thin: `rd.luks.name=` or `cryptdevice=` for the LVM PV
+- SecureBoot enabled: correct signing command in post-generation hook
+- BIOS/legacy boot: `GRUB_TERMINAL=console` set, no EFI-specific options
+
+---
+
+### 6. `configure/users.rs` — User creation
+
+**Risk: MEDIUM** — User account setup involves `useradd`, `passwd`, `usermod`, and group
+membership. Errors lock users out of the installed system.
+
+**Problem:** All functions shell out to external commands.
+
+**Recommended fix:** Test via `CommandRunner::new(true)` (dry-run). The dry-run runner logs
+commands without executing them; capturing output with `assert!(...)` on the logged strings
+confirms the right commands are built. Alternatively, add a mock `CommandRunner` variant.
+Scenarios to cover:
+
+- `useradd` invoked with the correct username and home directory
+- Password is set via `chpasswd` (not `passwd`) for non-interactive use
+- Configured groups are all passed to `usermod -aG`
+- Root password set when `config.user.root_password` is provided
+
+---
+
+### 7. `disk/formatting.rs` — Filesystem creation
+
+**Risk: MEDIUM** — Wrong filesystem type or missing formatting step leads to an unbootable
+partition. The module currently has no tests and wraps `mkfs.*` commands.
+
+**Problem:** Requires real block devices.
+
+**Recommended fix:** Integration tests in `tests/` using `losetup` with a sparse image file, or
+dry-run mode tests that assert the correct `mkfs.*` variant is invoked for each filesystem enum
+value (Btrfs, Ext4, Xfs, F2fs). Key assertions:
+
+- `Filesystem::Btrfs` → `mkfs.btrfs`
+- `Filesystem::Ext4` → `mkfs.ext4`
+- EFI partition always uses `mkfs.fat -F32`
+- Swap partition always uses `mkswap`
+
+---
+
+### 8. `configure/secureboot.rs` — Key enrollment & signing
+
+**Risk: MEDIUM** — SecureBoot mis-configuration (wrong key paths, missing signing step) causes
+firmware to refuse to boot the signed bootloader.
+
+**Problem:** Most operations shell out to `sbctl`, `openssl`, and `sbsign`.
+
+**Recommended fix:** Extract pure helpers that can be tested in isolation:
+
+- `get_signing_key_paths(config, install_root)` — already pure, should have a test asserting
+  that the paths differ between `Sbctl` and `ManualKeys` methods
+- `print_enrollment_instructions(config)` — pure output, can be tested by capturing stdout
+- `sign_efi_binary` command construction — testable via dry-run
+
+---
+
+### 9. `configure/swap.rs` — ZRAM service file generation
+
+**Risk: LOW-MEDIUM** — The four `setup_zram_*` helpers (`runit`, `openrc`, `s6`, `dinit`) write
+init-specific service files. Wrong paths or missing `ExecStart` lines cause ZRAM swap never to
+activate.
+
+**Recommended fix:** Use `tempfile::tempdir()` as `install_root` and assert:
+
+- Service file written to the correct directory for each init system
+- File contains the configured `zram_percent` and `algorithm`
+- `mkswap` and `swapon` are referenced in all variants
+
+---
+
+### 10. `utils/deps.rs` — Dependency checking
+
+**Risk: LOW** — `check_dependencies` and `ensure_dependencies` determine which tools must be
+present before installation proceeds. A wrong package name mapping causes a confusing error
+message.
+
+**Recommended fix:** The `binary_to_package()` mapping table is a pure `HashMap`; test that:
+
+- Every key maps to a non-empty package name
+- Known critical binaries (`cryptsetup`, `grub-install`, `mkfs.btrfs`) are in the map
+- `required_binaries(config)` returns the expected set for a given layout/feature combination
+
+---
+
+## Summary Table
+
+| Priority | Module | Tests to add | Blocker to unblock |
+|----------|--------|--------------|--------------------|
+| High | `config/deployment.rs` | ~12 (validate rules) | Extract `validate_rules()` |
+| High | `install/fstab.rs` | ~10 (content format) | Injectable UUID provider |
+| High | `disk/layouts.rs` | ~8 (layout computation) | Expose `compute_*` with disk_mib arg |
+| High | `install/crypttab.rs` | ~5 (multi-volume format) | Injectable UUID provider |
+| Med-High | `configure/bootloader.rs` | ~6 (GRUB config) | `tempdir` as install_root |
+| Medium | `configure/users.rs` | ~4 (command construction) | dry-run mode assertions |
+| Medium | `disk/formatting.rs` | ~5 (mkfs dispatch) | dry-run mode assertions |
+| Medium | `configure/secureboot.rs` | ~4 (pure helpers) | Expose `get_signing_key_paths` |
+| Low-Med | `configure/swap.rs` | ~4 (service files) | `tempdir` as install_root |
+| Low | `utils/deps.rs` | ~3 (mapping table) | None (pure functions) |

--- a/src/configure/encryption.rs
+++ b/src/configure/encryption.rs
@@ -587,3 +587,40 @@ pub fn close_multi_luks(cmd: &CommandRunner, containers: &[LuksContainer]) -> Re
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── to_title_case ────────────────────────────────────────────────────────
+
+    #[test]
+    fn to_title_case_capitalizes_first_letter_lowercase_rest() {
+        assert_eq!(to_title_case("root"), "Root");
+        assert_eq!(to_title_case("home"), "Home");
+        assert_eq!(to_title_case("usr"), "Usr");
+    }
+
+    #[test]
+    fn to_title_case_handles_already_uppercase_input() {
+        assert_eq!(to_title_case("ROOT"), "Root");
+        assert_eq!(to_title_case("HOME"), "Home");
+    }
+
+    #[test]
+    fn to_title_case_handles_mixed_case_input() {
+        assert_eq!(to_title_case("rOoT"), "Root");
+        assert_eq!(to_title_case("HoMe"), "Home");
+    }
+
+    #[test]
+    fn to_title_case_returns_empty_string_for_empty_input() {
+        assert_eq!(to_title_case(""), "");
+    }
+
+    #[test]
+    fn to_title_case_handles_single_character() {
+        assert_eq!(to_title_case("a"), "A");
+        assert_eq!(to_title_case("Z"), "Z");
+    }
+}

--- a/src/configure/swap.rs
+++ b/src/configure/swap.rs
@@ -528,3 +528,34 @@ pub fn configure_swap(
 pub fn swap_file_fstab_entry() -> String {
     format!("{}    none    swap    defaults    0    0\n", SWAP_FILE_PATH)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── swap_file_fstab_entry ────────────────────────────────────────────────
+
+    #[test]
+    fn swap_file_fstab_entry_uses_correct_swap_file_path() {
+        let entry = swap_file_fstab_entry();
+        assert!(
+            entry.contains(SWAP_FILE_PATH),
+            "fstab entry must reference SWAP_FILE_PATH, got: {}",
+            entry
+        );
+    }
+
+    #[test]
+    fn swap_file_fstab_entry_has_swap_type_and_defaults() {
+        let entry = swap_file_fstab_entry();
+        assert!(entry.contains("swap"), "fstab entry must specify type=swap");
+        assert!(entry.contains("none"), "fstab entry mount point must be 'none'");
+        assert!(entry.contains("defaults"), "fstab entry must include 'defaults' options");
+    }
+
+    #[test]
+    fn swap_file_fstab_entry_ends_with_newline() {
+        let entry = swap_file_fstab_entry();
+        assert!(entry.ends_with('\n'), "fstab entry must end with newline");
+    }
+}

--- a/src/disk/detection.rs
+++ b/src/disk/detection.rs
@@ -241,3 +241,56 @@ pub fn get_ram_mib() -> u64 {
     // Fallback: 8GB
     8192
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── partition_prefix ─────────────────────────────────────────────────────
+
+    #[test]
+    fn partition_prefix_appends_p_for_nvme_device() {
+        assert_eq!(partition_prefix("/dev/nvme0n1"), "/dev/nvme0n1p");
+        assert_eq!(partition_prefix("/dev/nvme1n2"), "/dev/nvme1n2p");
+    }
+
+    #[test]
+    fn partition_prefix_appends_p_for_mmcblk_device() {
+        assert_eq!(partition_prefix("/dev/mmcblk0"), "/dev/mmcblk0p");
+    }
+
+    #[test]
+    fn partition_prefix_appends_p_for_loop_device() {
+        assert_eq!(partition_prefix("/dev/loop0"), "/dev/loop0p");
+    }
+
+    #[test]
+    fn partition_prefix_no_suffix_for_sata_drive() {
+        assert_eq!(partition_prefix("/dev/sda"), "/dev/sda");
+        assert_eq!(partition_prefix("/dev/sdb"), "/dev/sdb");
+    }
+
+    #[test]
+    fn partition_prefix_no_suffix_for_virtio_drive() {
+        assert_eq!(partition_prefix("/dev/vda"), "/dev/vda");
+    }
+
+    // ── partition_path ───────────────────────────────────────────────────────
+
+    #[test]
+    fn partition_path_sata_uses_direct_numbering() {
+        assert_eq!(partition_path("/dev/sda", 1), "/dev/sda1");
+        assert_eq!(partition_path("/dev/sda", 3), "/dev/sda3");
+    }
+
+    #[test]
+    fn partition_path_nvme_uses_p_separator() {
+        assert_eq!(partition_path("/dev/nvme0n1", 1), "/dev/nvme0n1p1");
+        assert_eq!(partition_path("/dev/nvme0n1", 2), "/dev/nvme0n1p2");
+    }
+
+    #[test]
+    fn partition_path_mmcblk_uses_p_separator() {
+        assert_eq!(partition_path("/dev/mmcblk0", 1), "/dev/mmcblk0p1");
+    }
+}

--- a/src/install/crypttab.rs
+++ b/src/install/crypttab.rs
@@ -198,3 +198,21 @@ pub fn generate_crypttab_multi_volume(
     );
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── crypttab_options ─────────────────────────────────────────────────────
+
+    #[test]
+    fn crypttab_options_without_integrity_includes_discard() {
+        assert_eq!(crypttab_options(false), "luks,discard");
+    }
+
+    #[test]
+    fn crypttab_options_with_integrity_omits_discard() {
+        // dm-integrity is incompatible with TRIM/discard
+        assert_eq!(crypttab_options(true), "luks");
+    }
+}


### PR DESCRIPTION
Adds 35 new unit tests targeting pure, I/O-free functions that were
previously untested, bringing the total test count from 33 to 68:

- disk/layouts.rs: floor_align, clamp, calculate_swap_mib alignment,
  get_luks_partitions filtering, has_usr_partition, standard_subvolumes
- disk/detection.rs: partition_prefix (nvme/mmcblk/sata/virtio),
  partition_path for all device families
- config/deployment.rs: CustomPartitionEntry::effective_label (label
  derivation from mount point), is_encrypted (global inheritance and
  per-partition override), InitSystem base_package/service_dir/enabled_dir
- install/crypttab.rs: crypttab_options integrity vs discard behavior
- configure/swap.rs: swap_file_fstab_entry format and newline
- configure/encryption.rs: to_title_case all cases including edge cases

Also adds docs/test-coverage-proposal.md with a ranked list of 10 areas
that need test improvement, each with the specific blocker to overcome
(device-existence check in validate(), UUID provider coupling in fstab,
etc.) and concrete test scenarios to implement.

https://claude.ai/code/session_01AjmtaG8qRBfnULnGHF1FbA