### PR TITLE
Fix five logical errors found during code review

### DIFF
--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -412,7 +412,13 @@ impl Installer {
         info!("[Phase 3/6] Generating /etc/fstab with partition UUIDs");
 
         let layout = self.layout.as_ref().unwrap();
-        generate_fstab(&self.cmd, &self.config.disk.device, layout, INSTALL_ROOT)?;
+        generate_fstab(
+            &self.cmd,
+            &self.config.disk.device,
+            layout,
+            INSTALL_ROOT,
+            &self.config.disk.filesystem,
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
Bug 1 (users.rs): Shell injection via password in chpasswd command.
The password was embedded directly in a shell string using single-quote
wrapping, which breaks on passwords containing `'` and enables injection
of other shell metacharacters. Fixed by writing credentials to a
mode-0600 temp file inside the chroot and redirecting stdin from it,
so the password never appears in the shell command string.  Applied to
both create_user() and set_root_password().

Bug 2 (partitioning.rs): Silent data-loss when device info unavailable.
generate_sfdisk_script() silently fell back to total_sectors=0 when
get_device_info() failed.  A zero sector count produces an invalid GPT
partition table that could destroy data without surfacing an error.
Changed the function to return Result<String> and propagate the error
immediately.

Bug 3 (fstab.rs): generate_fstab() ignored the configured filesystem
type and always wrote "btrfs" for non-EFI, non-swap partitions.  Users
choosing ext4, xfs, or f2fs would get a fstab that causes boot failures.
Added a `filesystem: &Filesystem` parameter and derive the correct
fstype string and mount options (compress=zstd only for btrfs) from it.
Updated the single call site in installer.rs accordingly.

Bug 4 (fstab.rs): generate_fstab_with_subvolumes() called
layout.subvolumes.as_ref().unwrap(), which panics if the internal
invariant (uses_subvolumes() == true implies subvolumes.is_some()) is
ever violated.  Replaced with ok_or_else() to return a proper error.

Bug 5 (fstab.rs): Dead code in generate_fstab_with_subvolumes().
The branch `else if let Some(mount_point) = part.mount_point` is only
reached when !part.is_efi && !part.is_swap, so the inner check
`if part.is_efi { "vfat" } else { "btrfs" }` can never pick "vfat".
Removed the unreachable condition.

https://claude.ai/code/session_01PCZnH1LUqtsELq5AKKcygP