### PR TITLE
Fix is_bios_boot semantics and add configurable boot filesystem

### DIFF
--- a/src/disk/layouts.rs
+++ b/src/disk/layouts.rs
@@ -292,9 +292,12 @@ fn compute_standard_layout(disk_mib: u64) -> Result<ComputedLayout> {
             is_swap: false,
             is_efi: false,
             is_luks: false,
-            is_bios_boot: false,
+            // is_bios_boot = true sets the GPT LegacyBIOSBootable attribute bit
+            // (the "bootable" flag in fdisk/sfdisk expert mode), enabling GRUB
+            // to locate this partition on legacy BIOS systems.
+            is_bios_boot: true,
             is_boot_fs: true,
-            attributes: Some("LegacyBIOSBootable".to_string()),
+            attributes: None,
         },
         PartitionDef {
             number: 3,
@@ -412,9 +415,9 @@ fn compute_minimal_layout(disk_mib: u64) -> Result<ComputedLayout> {
             is_swap: false,
             is_efi: false,
             is_luks: false,
-            is_bios_boot: false,
+            is_bios_boot: true,
             is_boot_fs: true,
-            attributes: Some("LegacyBIOSBootable".to_string()),
+            attributes: None,
         },
         PartitionDef {
             number: 3,
@@ -504,9 +507,9 @@ fn compute_lvm_thin_layout(disk_mib: u64, use_swap_partition: bool) -> Result<Co
             is_swap: false,
             is_efi: false,
             is_luks: false,
-            is_bios_boot: false,
+            is_bios_boot: true,
             is_boot_fs: true,
-            attributes: Some("LegacyBIOSBootable".to_string()),
+            attributes: None,
         },
     ];
 
@@ -617,9 +620,9 @@ fn compute_custom_layout(
             is_swap: false,
             is_efi: false,
             is_luks: false,
-            is_bios_boot: false,
+            is_bios_boot: true,
             is_boot_fs: true,
-            attributes: Some("LegacyBIOSBootable".to_string()),
+            attributes: None,
         },
     ];
 

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -36,13 +36,31 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
         "linux-zen-headers".to_string(),
     ]);
 
-    // Filesystem tools
+    // Filesystem tools — always include btrfs-progs as it is commonly needed
     packages.push("btrfs-progs".to_string());
+    // Data filesystem tools
     match config.disk.filesystem {
         Filesystem::Ext4 => packages.push("e2fsprogs".to_string()),
         Filesystem::Xfs => packages.push("xfsprogs".to_string()),
         Filesystem::F2fs => packages.push("f2fs-tools".to_string()),
-        Filesystem::Btrfs => {} // Already added
+        Filesystem::Zfs => packages.push("zfs-utils".to_string()),
+        Filesystem::Btrfs => {} // Already added above
+    }
+    // Boot filesystem tools (if different from data filesystem)
+    match config.disk.boot_filesystem {
+        Filesystem::Ext4 if config.disk.filesystem != Filesystem::Ext4 => {
+            packages.push("e2fsprogs".to_string());
+        }
+        Filesystem::Xfs if config.disk.filesystem != Filesystem::Xfs => {
+            packages.push("xfsprogs".to_string());
+        }
+        Filesystem::F2fs if config.disk.filesystem != Filesystem::F2fs => {
+            packages.push("f2fs-tools".to_string());
+        }
+        Filesystem::Zfs if config.disk.filesystem != Filesystem::Zfs => {
+            packages.push("zfs-utils".to_string());
+        }
+        _ => {} // same as data filesystem or btrfs (already added)
     }
 
     // Bootloader


### PR DESCRIPTION
- is_bios_boot now correctly represents the GPT LegacyBIOSBootable
  attribute bit (the "Bootable" flag toggled in fdisk/sfdisk expert
  mode). It is set to true on every /boot partition across all layouts
  (standard, minimal, lvm-thin, custom) so the sfdisk script generator
  derives the attribute from the flag rather than from a hardcoded
  attributes string.

- partitioning.rs: generate_sfdisk_script() now emits attrs=
  "LegacyBIOSBootable" when is_bios_boot is true, replacing the
  previous hardcoded attributes field approach. The attributes field
  is preserved for any additional custom GPT attributes.

- formatting.rs: replace format_boot() (hardcoded mkfs.btrfs) with
  format_boot_partition() which accepts a Filesystem parameter and
  delegates to format_partition(). The /boot filesystem partition
  (is_boot_fs) is now formatted with the user-chosen boot filesystem
  rather than always btrfs. The erroneous is_bios_boot -> mkfs.btrfs
  branch in format_all_partitions() is removed; is_bios_boot is a
  partitioning/attribute concern, not a formatting concern.

- deployment.rs: add boot_filesystem: Filesystem field to DiskConfig
  (default: Ext4 for widest GRUB compatibility). Add Zfs variant to the
  Filesystem enum. Boot filesystem is selectable in the wizard from
  ext4, btrfs, xfs, zfs, f2fs. Validation prevents ZFS + boot
  encryption (LUKS1) combination.

- installer.rs: update all call sites (format_all_partitions,
  format_boot_partition, ensure_dependencies) to pass boot_filesystem.

- deps.rs: required_binaries/check_dependencies/ensure_dependencies
  now accept boot_filesystem; add zpool to the binary-to-package map
  for ZFS support; remove the hardcoded "boot uses ext4" fallback.

- basestrap.rs / mkinitcpio.rs: handle Filesystem::Zfs in all match
  arms; add boot filesystem packages/modules when different from the
  data filesystem.

https://claude.ai/code/session_01BKyyDv55f2rd646jeuuzBL