### PR TITLE
Add deploytix and related packages to ISO and target install lists

### DIFF
--- a/iso/profile/deploytix/profile.yaml
+++ b/iso/profile/deploytix/profile.yaml
@@ -44,3 +44,5 @@ rootfs:
 livefs:
   packages:
     - deploytix-git
+    - dosfstools
+    - artools

--- a/iso/profile/deploytix/profile.yaml
+++ b/iso/profile/deploytix/profile.yaml
@@ -44,5 +44,6 @@ rootfs:
 livefs:
   packages:
     - deploytix-git
+    - tkg-gui-git
     - dosfstools
     - artools

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -71,6 +71,13 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
     // Bootloader
     packages.extend(["efibootmgr".to_string(), "grub".to_string()]);
 
+    // Deploytix — install itself on the target system so it remains available
+    // after first boot; dosfstools is always required for the FAT32 EFI partition.
+    packages.extend([
+        "deploytix-git".to_string(),
+        "dosfstools".to_string(),
+    ]);
+
     // Essential tools
     packages.extend([
         "git".to_string(),

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -71,10 +71,12 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
     // Bootloader
     packages.extend(["efibootmgr".to_string(), "grub".to_string()]);
 
-    // Deploytix — install itself on the target system so it remains available
-    // after first boot; dosfstools is always required for the FAT32 EFI partition.
+    // Deploytix — install itself and tkg-gui on the target system so they
+    // remain available after first boot for re-deployment and kernel builds.
+    // dosfstools is always required for the FAT32 EFI partition.
     packages.extend([
         "deploytix-git".to_string(),
+        "tkg-gui-git".to_string(),
         "dosfstools".to_string(),
     ]);
 


### PR DESCRIPTION
- basestrap.rs: add deploytix-git (self-install on target system) and
  dosfstools (always needed for FAT32 EFI partition formatting) to the
  package list that basestrap installs onto the target disk
- profile.yaml: add dosfstools and artools to livefs.packages so the
  live USB session has the EFI formatting tool and the artools basestrap
  command available at runtime

https://claude.ai/code/session_015cjejyJ8JFzfLx1XzGbFvk