### PR TITLE
feat: add preserve home partition option for reinstall

### DIFF
--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -690,6 +690,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 2,
@@ -703,6 +704,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 3,
@@ -716,6 +718,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 4,
@@ -729,6 +732,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 5,
@@ -742,6 +746,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 6,
@@ -755,6 +760,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 7,
@@ -768,6 +774,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
             ],
             total_mib: 100000,
@@ -793,6 +800,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 2,
@@ -806,6 +814,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 3,
@@ -819,6 +828,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 4,
@@ -832,6 +842,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
             ],
             total_mib: 100000,

--- a/src/disk/formatting.rs
+++ b/src/disk/formatting.rs
@@ -155,6 +155,15 @@ pub fn format_all_partitions(
     for part in &layout.partitions {
         let part_path = partition_path(device, part.number);
 
+        // Skip preserved partitions — their existing filesystem is kept intact
+        if part.preserve {
+            info!(
+                "Preserving existing filesystem on {} ({}) — not reformatting",
+                part_path, part.name
+            );
+            continue;
+        }
+
         if part.is_efi {
             format_efi(cmd, &part_path)?;
         } else if part.is_bios_boot && !part.is_boot_fs {

--- a/src/disk/partitioning.rs
+++ b/src/disk/partitioning.rs
@@ -9,6 +9,93 @@ use std::io::Write;
 use tracing::info;
 use uuid::Uuid;
 
+/// Existing partition info read from the current partition table.
+struct ExistingPartition {
+    /// Start sector
+    start: u64,
+    /// Size in sectors
+    size: u64,
+    /// GPT partition UUID
+    uuid: String,
+}
+
+/// Read existing partition boundaries from the current partition table using sfdisk --dump.
+/// Returns a map from partition number to (start_sector, size_sectors, uuid).
+fn read_existing_partitions(device: &str) -> Result<std::collections::HashMap<u32, ExistingPartition>> {
+    let output = std::process::Command::new("sfdisk")
+        .args(["--dump", device])
+        .output()
+        .map_err(|e| DeploytixError::PartitionError(format!(
+            "Failed to read existing partition table from {}: {}", device, e
+        )))?;
+
+    if !output.status.success() {
+        return Err(DeploytixError::PartitionError(format!(
+            "sfdisk --dump failed for {}: {}",
+            device,
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+
+    let dump = String::from_utf8_lossy(&output.stdout);
+    let mut map = std::collections::HashMap::new();
+
+    for line in dump.lines() {
+        // Lines look like: /dev/sda7 : start=   123456, size=  789012, type=..., uuid=..., name="HOME"
+        let line = line.trim();
+        if !line.starts_with(device) {
+            continue;
+        }
+
+        // Extract partition number from path (e.g., /dev/sda7 -> 7, /dev/nvme0n1p7 -> 7)
+        let part_path = line.split(':').next().unwrap_or("").trim();
+        let part_num = extract_partition_number(part_path);
+        if part_num == 0 {
+            continue;
+        }
+
+        // Parse key=value pairs after the colon
+        let kv_part = match line.split_once(':') {
+            Some((_, rest)) => rest,
+            None => continue,
+        };
+
+        let mut start = 0u64;
+        let mut size = 0u64;
+        let mut uuid = String::new();
+
+        for field in kv_part.split(',') {
+            let field = field.trim();
+            if let Some(val) = field.strip_prefix("start=") {
+                start = val.trim().parse().unwrap_or(0);
+            } else if let Some(val) = field.strip_prefix("size=") {
+                size = val.trim().parse().unwrap_or(0);
+            } else if let Some(val) = field.strip_prefix("uuid=") {
+                uuid = val.trim().to_string();
+            }
+        }
+
+        if start > 0 && size > 0 {
+            map.insert(part_num, ExistingPartition { start, size, uuid });
+        }
+    }
+
+    Ok(map)
+}
+
+/// Extract partition number from a device path like /dev/sda7 or /dev/nvme0n1p7.
+fn extract_partition_number(path: &str) -> u32 {
+    // Find the last run of digits
+    let digits: String = path.chars().rev().take_while(|c| c.is_ascii_digit()).collect();
+    let digits: String = digits.chars().rev().collect();
+    digits.parse().unwrap_or(0)
+}
+
+/// Check if any partition in the layout is marked as preserved.
+fn has_preserved_partitions(layout: &ComputedLayout) -> bool {
+    layout.partitions.iter().any(|p| p.preserve)
+}
+
 /// Generate sfdisk script for a partition layout
 pub fn generate_sfdisk_script(device: &str, layout: &ComputedLayout) -> Result<String> {
     let device_info = get_device_info(device).map_err(|e| {
@@ -22,6 +109,13 @@ pub fn generate_sfdisk_script(device: &str, layout: &ComputedLayout) -> Result<S
 
     let first_lba = 2048u64;
     let last_lba = total_sectors.saturating_sub(34);
+
+    // If any partitions are preserved, read the existing table to get their boundaries
+    let existing = if has_preserved_partitions(layout) {
+        Some(read_existing_partitions(device)?)
+    } else {
+        None
+    };
 
     let label_id = Uuid::new_v4();
 
@@ -39,45 +133,94 @@ pub fn generate_sfdisk_script(device: &str, layout: &ComputedLayout) -> Result<S
     let mut current_sector = first_lba;
 
     for (i, part) in layout.partitions.iter().enumerate() {
-        let part_uuid = Uuid::new_v4();
         let part_path = partition_path(device, part.number);
 
-        // Calculate size in sectors
-        let size_sectors = if part.size_mib == 0 {
-            // Remainder - use all remaining space
-            last_lba - current_sector + 1
+        if part.preserve {
+            // Preserved partition: use existing boundaries from disk
+            let existing_map = existing.as_ref().ok_or_else(|| {
+                DeploytixError::PartitionError(
+                    "Cannot preserve partition: failed to read existing partition table".to_string(),
+                )
+            })?;
+            let existing_part = existing_map.get(&part.number).ok_or_else(|| {
+                DeploytixError::PartitionError(format!(
+                    "Cannot preserve partition {}: not found in existing partition table on {}",
+                    part.number, device
+                ))
+            })?;
+
+            info!(
+                "Preserving partition {} ({}) at start={}, size={}",
+                part.number, part.name, existing_part.start, existing_part.size
+            );
+
+            // Use existing UUID to maintain filesystem references
+            let part_uuid = &existing_part.uuid;
+            let mut line = format!(
+                "{} : start={}, size={}, type={}, uuid={}, name=\"{}\"",
+                part_path, existing_part.start, existing_part.size, part.type_guid, part_uuid, part.name
+            );
+
+            let mut attrs: Vec<String> = Vec::new();
+            if part.is_bios_boot {
+                attrs.push("LegacyBIOSBootable".to_string());
+            }
+            if let Some(ref extra) = part.attributes {
+                attrs.push(extra.clone());
+            }
+            if !attrs.is_empty() {
+                line.push_str(&format!(", attrs=\"{}\"", attrs.join(",")));
+            }
+
+            script.push_str(&line);
+            script.push('\n');
+
+            // Update position past the preserved partition
+            current_sector = existing_part.start + existing_part.size;
+            if i < layout.partitions.len() - 1 {
+                current_sector = current_sector.div_ceil(align_sectors) * align_sectors;
+            }
         } else {
-            (part.size_mib * 1024 * 1024) / sector_size
-        };
+            // New partition: compute fresh boundaries
+            let part_uuid = Uuid::new_v4();
 
-        // Build partition line
-        let mut line = format!(
-            "{} : start={}, size={}, type={}, uuid={}, name=\"{}\"",
-            part_path, current_sector, size_sectors, part.type_guid, part_uuid, part.name
-        );
+            // Calculate size in sectors
+            let size_sectors = if part.size_mib == 0 {
+                // Remainder - use all remaining space
+                last_lba - current_sector + 1
+            } else {
+                (part.size_mib * 1024 * 1024) / sector_size
+            };
 
-        // Add GPT attributes.
-        // is_bios_boot maps to the LegacyBIOSBootable GPT attribute bit — the
-        // same flag toggled by fdisk's expert-mode "Bootable" option, which
-        // tells GRUB where the /boot filesystem lives on legacy BIOS systems.
-        let mut attrs: Vec<String> = Vec::new();
-        if part.is_bios_boot {
-            attrs.push("LegacyBIOSBootable".to_string());
-        }
-        if let Some(ref extra) = part.attributes {
-            attrs.push(extra.clone());
-        }
-        if !attrs.is_empty() {
-            line.push_str(&format!(", attrs=\"{}\"", attrs.join(",")));
-        }
+            // Build partition line
+            let mut line = format!(
+                "{} : start={}, size={}, type={}, uuid={}, name=\"{}\"",
+                part_path, current_sector, size_sectors, part.type_guid, part_uuid, part.name
+            );
 
-        script.push_str(&line);
-        script.push('\n');
+            // Add GPT attributes.
+            // is_bios_boot maps to the LegacyBIOSBootable GPT attribute bit — the
+            // same flag toggled by fdisk's expert-mode "Bootable" option, which
+            // tells GRUB where the /boot filesystem lives on legacy BIOS systems.
+            let mut attrs: Vec<String> = Vec::new();
+            if part.is_bios_boot {
+                attrs.push("LegacyBIOSBootable".to_string());
+            }
+            if let Some(ref extra) = part.attributes {
+                attrs.push(extra.clone());
+            }
+            if !attrs.is_empty() {
+                line.push_str(&format!(", attrs=\"{}\"", attrs.join(",")));
+            }
 
-        // Update position for next partition (aligned)
-        if i < layout.partitions.len() - 1 {
-            let next_sector = current_sector + size_sectors;
-            current_sector = next_sector.div_ceil(align_sectors) * align_sectors;
+            script.push_str(&line);
+            script.push('\n');
+
+            // Update position for next partition (aligned)
+            if i < layout.partitions.len() - 1 {
+                let next_sector = current_sector + size_sectors;
+                current_sector = next_sector.div_ceil(align_sectors) * align_sectors;
+            }
         }
     }
 
@@ -86,10 +229,13 @@ pub fn generate_sfdisk_script(device: &str, layout: &ComputedLayout) -> Result<S
 
 /// Apply partition layout to a disk using sfdisk
 pub fn apply_partitions(cmd: &CommandRunner, device: &str, layout: &ComputedLayout) -> Result<()> {
+    let preserving = has_preserved_partitions(layout);
+
     info!(
-        "Applying {} partition layout to {}",
+        "Applying {} partition layout to {}{}",
         layout.partitions.len(),
-        device
+        device,
+        if preserving { " (preserving marked partitions)" } else { "" }
     );
 
     // Generate sfdisk script
@@ -110,13 +256,28 @@ pub fn apply_partitions(cmd: &CommandRunner, device: &str, layout: &ComputedLayo
     file.write_all(script.as_bytes())?;
     drop(file);
 
-    // Wipe existing partition table
-    info!("Wiping existing partition table on {}...", device);
-    let _ = cmd.run("wipefs", &["-a", device]);
+    if preserving {
+        // When preserving partitions, do NOT wipe the partition table.
+        // Use sfdisk --force to rewrite the table while keeping preserved
+        // partition data intact on disk.
+        info!(
+            "Rewriting partition table on {} (preserving home)...",
+            device
+        );
+    } else {
+        // Wipe existing partition table for a clean install
+        info!("Wiping existing partition table on {}...", device);
+        let _ = cmd.run("wipefs", &["-a", device]);
+    }
 
-    // Apply with sfdisk - pipe script via stdin from file
+    // Apply with sfdisk - pipe script via stdin from file.
+    // --force is needed when rewriting a table with existing partitions.
     info!("Writing new GPT partition table to {}...", device);
-    let result = std::process::Command::new("sfdisk")
+    let mut sfdisk_cmd = std::process::Command::new("sfdisk");
+    if preserving {
+        sfdisk_cmd.arg("--force");
+    }
+    let result = sfdisk_cmd
         .arg(device)
         .stdin(fs::File::open(script_path)?)
         .output()

--- a/src/disk/volumes.rs
+++ b/src/disk/volumes.rs
@@ -237,6 +237,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 2,
@@ -250,6 +251,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 3,
@@ -263,6 +265,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 4,
@@ -276,6 +279,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 5,
@@ -289,6 +293,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
             ],
             total_mib: 500000,
@@ -369,6 +374,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 2,
@@ -382,6 +388,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    preserve: false,
                 },
                 PartitionDef {
                     number: 3,
@@ -395,6 +402,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    preserve: false,
                 },
             ],
             total_mib: 500000,

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -94,6 +94,8 @@ pub struct DeploytixGui {
     zram_percent: u8,
     // Btrfs subvolumes
     use_subvolumes: bool,
+    // Preserve existing /home partition
+    preserve_home: bool,
     // LVM thin provisioning
     use_lvm_thin: bool,
     lvm_vg_name: String,
@@ -162,6 +164,7 @@ impl Default for DeploytixGui {
             swap_type: SwapType::Partition,
             zram_percent: 50,
             use_subvolumes: false,
+            preserve_home: false,
             use_lvm_thin: false,
             lvm_vg_name: "vg0".to_string(),
             lvm_thin_pool_name: "thinpool".to_string(),
@@ -272,6 +275,7 @@ impl DeploytixGui {
                 } else {
                     None
                 },
+                preserve_home: self.preserve_home,
             },
             system: SystemConfig {
                 init: self.init_system.clone(),
@@ -546,6 +550,7 @@ impl eframe::App for DeploytixGui {
                     &self.devices,
                     &mut self.selected_device_index,
                     &mut self.refreshing_disks,
+                    self.preserve_home,
                 ),
                 WizardStep::DiskConfig => panels::disk_config_panel(
                     ui,
@@ -558,6 +563,7 @@ impl eframe::App for DeploytixGui {
                     &mut self.swap_type,
                     &mut self.zram_percent,
                     &mut self.use_subvolumes,
+                    &mut self.preserve_home,
                     &mut self.use_lvm_thin,
                     &mut self.lvm_vg_name,
                     &mut self.lvm_thin_pool_name,
@@ -614,6 +620,7 @@ impl eframe::App for DeploytixGui {
                         &self.hostname,
                         &self.username,
                         self.encrypt_home,
+                        self.preserve_home,
                         &self.network_backend,
                         &self.desktop_env,
                         &mut self.dry_run,


### PR DESCRIPTION
Add a "Preserve Home" feature that allows reinstalling the system
without erasing the /home partition, keeping all user files intact.

Changes across the full stack:
- Config: `preserve_home` field on DiskConfig with validation rules
  (incompatible with Minimal layout, LVM thin, btrfs subvolumes)
- Layouts: `preserve` flag on PartitionDef, propagated from config
- Partitioning: reads existing partition table to preserve home's
  exact start/size boundaries; skips wipefs when preserving
- Formatting: skips reformatting preserved partitions
- Encryption: open_existing_luks() unlocks preserved LUKS containers
  without reformatting them
- Installer: updated pipeline to handle preserved partitions through
  all phases (partition, encrypt, format, mount)
- Users: skip home directory creation when it already exists on the
  preserved partition; ensure correct ownership
- GUI: checkbox in disk config panel (auto-disabled when incompatible
  options are selected), updated warnings in disk selection and
  summary panels

https://claude.ai/code/session_01Xy5zVaUBLRS4ApYUHeYdet