### PR TITLE
fix: include blockdev/blkid in initramfs for USB persistence mount

### DIFF
--- a/iso/build-deploytix-iso.sh
+++ b/iso/build-deploytix-iso.sh
@@ -366,11 +366,18 @@ install_profile() {
         cp "${PROFILE_SRC}/profile.yaml" "$dest/profile.yaml"
     fi
 
-    # Set root-overlay symlink to common using an absolute path so it resolves
-    # correctly regardless of whether common/ exists in the workspace.
+    # Merge root-overlay: start from the common artools overlay, then layer
+    # our profile-specific overlay on top (e.g. mkinitcpio conf.d drop-ins
+    # for COW persistence).
     local common_dir
     common_dir="$(resolve_common_dir)"
-    ln -sfn "${common_dir}/root-overlay" "$dest/root-overlay"
+    mkdir -p "$dest/root-overlay"
+    if [[ -d "${common_dir}/root-overlay" ]]; then
+        cp -aT "${common_dir}/root-overlay" "$dest/root-overlay"
+    fi
+    if [[ -d "${PROFILE_SRC}/root-overlay" ]]; then
+        cp -aT "${PROFILE_SRC}/root-overlay" "$dest/root-overlay"
+    fi
 
     # Copy live-overlay if it exists in our profile source
     if [[ -d "${PROFILE_SRC}/live-overlay" ]]; then

--- a/iso/profile/deploytix/root-overlay/etc/mkinitcpio.conf.d/cow-persistence.conf
+++ b/iso/profile/deploytix/root-overlay/etc/mkinitcpio.conf.d/cow-persistence.conf
@@ -1,0 +1,3 @@
+# Ensure blockdev and blkid are available in the initramfs for COW
+# persistence partition discovery (cow_label= kernel parameter).
+BINARIES+=(blockdev blkid)

--- a/iso/write-deploytix-usb.sh
+++ b/iso/write-deploytix-usb.sh
@@ -130,9 +130,8 @@ sync
 msg2 "ISO written successfully"
 
 # Wait for kernel to re-read partition table
-sleep 2
 partprobe "${DEVICE}" 2>/dev/null || true
-sleep 1
+udevadm settle --timeout=5 2>/dev/null || sleep 3
 
 # ── Step 2: Determine partition layout ───────────────────────────────────────
 msg "Inspecting partition layout..."
@@ -157,9 +156,10 @@ msg2 "Free space after ISO: $(( FREE_SECTORS * 512 / 1024 / 1024 )) MiB"
 msg "Creating persistence partition..."
 
 # Append partition 3 (Linux, type 83) using all remaining space
-echo ',,83,;' | sfdisk --append "${DEVICE}" --no-reread 2>/dev/null || true
+echo ',,83,;' | sfdisk --append "${DEVICE}" --no-reread \
+    || die "sfdisk --append failed; is the partition table intact?"
 partprobe "${DEVICE}" 2>/dev/null || true
-sleep 2
+udevadm settle --timeout=5 2>/dev/null || sleep 3
 
 # Find the new partition (usually ${DEVICE}3, but handle nvme-style names too)
 PERSIST_PART=""
@@ -169,6 +169,19 @@ for candidate in "${DEVICE}3" "${DEVICE}p3"; do
         break
     fi
 done
+
+# If the device node hasn't appeared yet, give the kernel another chance
+if [[ -z "${PERSIST_PART}" ]]; then
+    msg2 "Waiting for partition device node..."
+    partprobe "${DEVICE}" 2>/dev/null || true
+    udevadm settle --timeout=5 2>/dev/null || sleep 3
+    for candidate in "${DEVICE}3" "${DEVICE}p3"; do
+        if [[ -b "${candidate}" ]]; then
+            PERSIST_PART="${candidate}"
+            break
+        fi
+    done
+fi
 
 [[ -n "${PERSIST_PART}" ]] || die "Could not find persistence partition after creation"
 msg2 "Persistence partition: ${PERSIST_PART}"


### PR DESCRIPTION
The live boot initramfs needs blockdev and blkid to resolve the
cow_label= kernel parameter to a block device path. Without them
the persistence partition cannot be found on boot.

- Add mkinitcpio conf.d drop-in in root-overlay to pull blockdev
  and blkid into the initramfs via BINARIES
- Change build script root-overlay handling from a symlink to
  common → a merged copy so profile-specific overlay files
  (like the conf.d drop-in) are included
- Fix write script: stop suppressing sfdisk errors, replace
  arbitrary sleeps with udevadm settle, add retry logic for
  partition device node discovery

https://claude.ai/code/session_01S4dGjaoPFezN8mGLZKXWM7