### PR TITLE
Fix root-overlay symlink causing cp failure in GUI ISO builds

### DIFF
--- a/iso/build-deploytix-iso.sh
+++ b/iso/build-deploytix-iso.sh
@@ -371,7 +371,20 @@ install_profile() {
     # for COW persistence).
     local common_dir
     common_dir="$(resolve_common_dir)"
-    mkdir -p "$dest/root-overlay"
+    # If generate_gui_profile left a symlink (DE profiles often symlink
+    # root-overlay to ../common/root-overlay), materialise it into a real
+    # directory so we can layer additional files on top.
+    if [[ -L "$dest/root-overlay" ]]; then
+        local link_target
+        link_target="$(readlink -f "$dest/root-overlay")"
+        rm "$dest/root-overlay"
+        mkdir -p "$dest/root-overlay"
+        if [[ -d "$link_target" ]]; then
+            cp -aT "$link_target" "$dest/root-overlay"
+        fi
+    else
+        mkdir -p "$dest/root-overlay"
+    fi
     if [[ -d "${common_dir}/root-overlay" ]]; then
         cp -aT "${common_dir}/root-overlay" "$dest/root-overlay"
     fi


### PR DESCRIPTION
When building with -g (GUI), generate_gui_profile() creates a symlink at
$dest/root-overlay when the DE profile's root-overlay is itself a symlink
(e.g. plasma's ../common/root-overlay). The subsequent cp -aT in
install_profile() then fails with "cannot overwrite non-directory" because
it tries to replace the symlink with directory contents.

Materialise the symlink into a real directory before layering the common
and profile-specific overlays on top.

https://claude.ai/code/session_01HbsNzDQcqnJDYgv3ZALXTx