### PR TITLE
Fix yay AUR helper install failing due to /tmp/yay-build not persisting

### DIFF
--- a/src/configure/packages.rs
+++ b/src/configure/packages.rs
@@ -318,24 +318,21 @@ pub fn install_yay(
         "pacman -S --noconfirm --needed go git base-devel",
     )?;
 
-    // Create a temporary build directory owned by the user
-    cmd.run_in_chroot(
-        install_root,
-        &format!("mkdir -p /tmp/yay-build && chown {0}:{0} /tmp/yay-build", username),
-    )?;
-
-    // Clone and build yay as the non-root user
+    // Create build dir, clone, build, and clean up in a single chroot
+    // invocation.  artix-chroot may mount a tmpfs over /tmp, so a
+    // directory created in one invocation would not survive to the next.
     let build_cmd = format!(
-        "sudo -u {} bash -c 'cd /tmp/yay-build && \
-         git clone https://aur.archlinux.org/yay.git && \
-         cd yay && \
-         makepkg -si --noconfirm'",
+        "mkdir -p /tmp/yay-build && \
+         chown {0}:{0} /tmp/yay-build && \
+         sudo -u {0} bash -c '\
+           cd /tmp/yay-build && \
+           git clone https://aur.archlinux.org/yay.git && \
+           cd yay && \
+           makepkg -si --noconfirm' && \
+         rm -rf /tmp/yay-build",
         username
     );
     cmd.run_in_chroot(install_root, &build_cmd)?;
-
-    // Clean up build directory
-    cmd.run_in_chroot(install_root, "rm -rf /tmp/yay-build")?;
 
     info!("yay AUR helper installed successfully");
     Ok(())


### PR DESCRIPTION
artix-chroot may mount a tmpfs over /tmp, so the directory created by
mkdir in one chroot invocation does not survive to the next. Combine
the mkdir, chown, build, and cleanup into a single chroot call so
they all execute within the same mount namespace.

Fixes: "bash: line 1: cd: /tmp/yay-build: No such file or directory"

https://claude.ai/code/session_015zx8vWZWaopK4o8oYJ9YVy