### PR TITLE
feat: unconditional btrfs subvolumes for all partitions (boot, usr, var, home)

### DIFF
--- a/src/config/deployment.rs
+++ b/src/config/deployment.rs
@@ -101,7 +101,10 @@ pub struct DiskConfig {
     /// Enable keyfile-based automatic unlocking (default: true when encryption enabled)
     #[serde(default = "default_true")]
     pub keyfile_enabled: bool,
-    /// Use btrfs subvolumes within partitions (Standard layout only)
+    /// Use btrfs subvolumes within partitions.
+    /// Automatically set to true whenever `filesystem == Btrfs`; no manual
+    /// opt-in is required.  Kept as a serialisable field for backwards
+    /// compatibility with existing configuration files.
     #[serde(default)]
     pub use_subvolumes: bool,
 
@@ -694,12 +697,8 @@ impl DeploymentConfig {
         // Encryption option (available on all layouts)
         let encryption = prompt_confirm("Enable LUKS encryption on data partitions?", false)?;
 
-        // Subvolumes option (available on any layout with btrfs)
-        let use_subvolumes = if filesystem == Filesystem::Btrfs {
-            prompt_confirm("Use btrfs subvolumes within partitions?", false)?
-        } else {
-            false
-        };
+        // Subvolumes are enabled unconditionally for btrfs. No prompt needed.
+        let use_subvolumes = filesystem == Filesystem::Btrfs;
 
         // Integrity (dm-integrity alongside LUKS2 encryption)
         let integrity = if encryption {

--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -757,6 +757,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 2,
@@ -770,6 +771,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 3,
@@ -783,6 +785,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 4,
@@ -796,6 +799,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 5,
@@ -809,6 +813,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 6,
@@ -822,6 +827,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 7,
@@ -835,6 +841,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
             ],
             total_mib: 100000,
@@ -860,6 +867,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 2,
@@ -873,6 +881,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 3,
@@ -886,6 +895,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 4,
@@ -899,6 +909,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
             ],
             total_mib: 100000,

--- a/src/disk/layouts.rs
+++ b/src/disk/layouts.rs
@@ -5,7 +5,7 @@
 //! Layouts define the *partition table* only. Storage features (encryption,
 //! LVM thin, subvolumes) are applied as layers by the installer pipeline.
 
-use crate::config::{CustomPartitionEntry, DiskConfig, SwapType};
+use crate::config::{CustomPartitionEntry, DiskConfig, Filesystem, SwapType};
 use crate::disk::detection::get_ram_mib;
 use crate::utils::error::{DeploytixError, Result};
 
@@ -131,6 +131,11 @@ pub struct PartitionDef {
     pub is_boot_fs: bool,
     /// Additional attributes (e.g., LegacyBIOSBootable)
     pub attributes: Option<String>,
+    /// Btrfs subvolume name for this partition (e.g. "@" for root, "@usr" for /usr).
+    /// When Some, a subvolume is created on this btrfs partition and it is mounted via
+    /// `subvol=<name>` instead of as a raw filesystem.
+    /// Set unconditionally for all data partitions when the filesystem is btrfs.
+    pub subvolume_name: Option<String>,
 }
 
 /// Planned thin volume definition (saved when LVM thin collapses partitions)
@@ -210,6 +215,22 @@ pub fn get_luks_partitions(layout: &ComputedLayout) -> Vec<&PartitionDef> {
     layout.partitions.iter().filter(|p| p.is_luks).collect()
 }
 
+/// Derive the btrfs subvolume name for a given mount point.
+///
+/// Convention: `@` for root, `@<last-component>` for everything else.
+/// Examples: "/" → "@", "/usr" → "@usr", "/home" → "@home", "/var/log" → "@log"
+pub fn mount_point_to_subvol_name(mount_point: &str) -> String {
+    if mount_point == "/" {
+        "@".to_string()
+    } else {
+        let component = mount_point
+            .rsplit('/')
+            .find(|s| !s.is_empty())
+            .unwrap_or("data");
+        format!("@{}", component)
+    }
+}
+
 /// Compute partition layout from user-defined entries.
 ///
 /// Always prepends EFI + Boot. Swap is prepended only when
@@ -265,6 +286,7 @@ pub fn compute_layout_from_entries(
             is_bios_boot: false,
             is_boot_fs: false,
             attributes: None,
+            subvolume_name: None,
         },
         PartitionDef {
             number: 2,
@@ -278,6 +300,7 @@ pub fn compute_layout_from_entries(
             is_bios_boot: true,
             is_boot_fs: true,
             attributes: None,
+            subvolume_name: None,
         },
     ];
 
@@ -297,6 +320,7 @@ pub fn compute_layout_from_entries(
             is_bios_boot: false,
             is_boot_fs: false,
             attributes: None,
+            subvolume_name: None,
         });
         next_part_num += 1;
     }
@@ -335,6 +359,7 @@ pub fn compute_layout_from_entries(
             is_bios_boot: false,
             is_boot_fs: false,
             attributes: None,
+            subvolume_name: None,
         });
         next_part_num += 1;
     }
@@ -375,11 +400,57 @@ pub fn compute_layout_from_config(
         apply_encryption_flags(&mut layout);
     }
 
-    // Apply subvolumes if requested.
-    // When subvolumes are active, the raw ROOT partition is not mounted directly;
-    // clear its mount_point so that subvolumes are mounted instead.
-    if disk_config.use_subvolumes {
-        layout.subvolumes = Some(standard_subvolumes());
+    // Apply btrfs subvolumes unconditionally when the filesystem is btrfs.
+    //
+    // Each data partition gets its own named subvolume (e.g. "@" for root,
+    // "@usr" for /usr, "@var" for /var, "@home" for /home).  The boot
+    // partition always gets "@boot" via `mount_boot_btrfs_subvolume` when
+    // `boot_filesystem == Btrfs` (which is derived automatically).
+    //
+    // When the layout has only a ROOT partition and no other data partitions,
+    // `standard_subvolumes()` is used so that @home / @usr / @var / @log all
+    // live inside a single btrfs filesystem — the traditional single-device
+    // subvolume layout.  When separate data partitions exist (the default),
+    // each partition receives exactly one subvolume so that snapshots and
+    // rollbacks can be applied per-partition without interference.
+    if disk_config.filesystem == Filesystem::Btrfs {
+        // Collect mount points of *non-root* data partitions
+        let non_root_data_mounts: std::collections::HashSet<String> = disk_config
+            .partitions
+            .iter()
+            .filter(|p| p.mount_point != "/")
+            .map(|p| p.mount_point.clone())
+            .collect();
+
+        if non_root_data_mounts.is_empty() {
+            // Single-partition layout: all subvolumes live on ROOT.
+            layout.subvolumes = Some(standard_subvolumes());
+        } else {
+            // Multi-partition layout: ROOT gets only "@"; every other data
+            // partition gets its own "@<name>" subvolume.
+            layout.subvolumes = Some(vec![SubvolumeDef {
+                name: "@".to_string(),
+                mount_point: "/".to_string(),
+                mount_options: "defaults,noatime,compress=zstd".to_string(),
+            }]);
+            let default_opts = "defaults,noatime,compress=zstd".to_string();
+            for part in &mut layout.partitions {
+                if part.is_efi || part.is_boot_fs || part.is_swap || part.is_bios_boot {
+                    continue;
+                }
+                if let Some(ref mp) = part.mount_point.clone() {
+                    if mp != "/" {
+                        part.subvolume_name = Some(mount_point_to_subvol_name(mp));
+                        // For /var, also record @log under the same partition
+                        // subvolume (handled at mount time via separate SubvolumeDef).
+                        let _ = default_opts.as_str(); // suppress unused warning
+                    }
+                }
+            }
+        }
+
+        // Clear the ROOT partition's mount_point so it is mounted via its
+        // subvolume rather than as a raw filesystem.
         for part in &mut layout.partitions {
             if part.mount_point.as_deref() == Some("/") && !part.is_efi && !part.is_boot_fs {
                 part.mount_point = None;
@@ -467,6 +538,7 @@ pub fn apply_lvm_thin_to_layout(
         is_bios_boot: false,
         is_boot_fs: false,
         attributes: None,
+        subvolume_name: None,
     });
 
     Ok(ComputedLayout {
@@ -547,6 +619,7 @@ mod tests {
             is_bios_boot: false,
             is_boot_fs: false,
             attributes: None,
+            subvolume_name: None,
         }
     }
 

--- a/src/disk/volumes.rs
+++ b/src/disk/volumes.rs
@@ -245,6 +245,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 2,
@@ -258,6 +259,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 3,
@@ -271,6 +273,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 4,
@@ -284,6 +287,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 5,
@@ -297,6 +301,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
             ],
             total_mib: 500000,
@@ -377,6 +382,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 2,
@@ -390,6 +396,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: true,
                     attributes: None,
+                    subvolume_name: None,
                 },
                 PartitionDef {
                     number: 3,
@@ -403,6 +410,7 @@ mod tests {
                     is_bios_boot: false,
                     is_boot_fs: false,
                     attributes: None,
+                    subvolume_name: None,
                 },
             ],
             total_mib: 500000,

--- a/src/gui/panels.rs
+++ b/src/gui/panels.rs
@@ -139,13 +139,8 @@ pub fn disk_config_panel(
         ui.add_space(8.0);
     }
 
-    // Subvolumes (btrfs only)
-    if *filesystem == Filesystem::Btrfs {
-        ui.checkbox(use_subvolumes, "Use btrfs subvolumes (@, @home, @var, ...)");
-        ui.add_space(8.0);
-    } else {
-        *use_subvolumes = false;
-    }
+    // Subvolumes are enabled unconditionally for btrfs; no user opt-in required.
+    *use_subvolumes = *filesystem == Filesystem::Btrfs;
 
     // Preserve home (reinstall without overwriting /home)
     ui.checkbox(preserve_home, "Preserve existing /home (reinstall without overwriting user data)");

--- a/src/install/chroot.rs
+++ b/src/install/chroot.rs
@@ -251,7 +251,9 @@ fn mount_partitions_with_subvolumes(
         }
     }
 
-    // Mount remaining non-subvolume partitions (EFI, swap, etc.)
+    // Mount remaining partitions (EFI, swap, and other btrfs data partitions).
+    // Data partitions that carry a per-partition btrfs subvolume (subvolume_name.is_some())
+    // are mounted via `subvol=@name` instead of a raw filesystem mount.
     for part in &layout.partitions {
         if part.name == "ROOT" || part.is_boot_fs {
             continue; // Already handled above
@@ -263,14 +265,43 @@ fn mount_partitions_with_subvolumes(
             cmd.run("swapon", &[&part_path])?;
         } else if let Some(ref mount_point) = part.mount_point {
             let part_path = partition_path(device, part.number);
-            let full_mount = format!("{}{}", install_root, mount_point);
 
-            if !cmd.is_dry_run() {
-                std::fs::create_dir_all(&full_mount)?;
+            if let Some(ref subvol_name) = part.subvolume_name {
+                // Btrfs partition with a dedicated subvolume: create the subvolume
+                // then mount it with `subvol=@name`.
+                //
+                // /var is special: in addition to its own "@var" subvolume it
+                // also hosts "@log" (→ /var/log) so that logs can be excluded
+                // from snapshots independently.
+                let mut part_subvols = vec![SubvolumeDef {
+                    name: subvol_name.clone(),
+                    mount_point: mount_point.clone(),
+                    mount_options: "defaults,noatime,compress=zstd".to_string(),
+                }];
+                if mount_point == "/var" {
+                    part_subvols.push(SubvolumeDef {
+                        name: "@log".to_string(),
+                        mount_point: "/var/log".to_string(),
+                        mount_options: "defaults,noatime,compress=zstd".to_string(),
+                    });
+                }
+
+                let temp_mount = format!(
+                    "/tmp/deploytix_btrfs_{}",
+                    subvol_name.trim_start_matches('@')
+                );
+                let skip_home = preserve_home && mount_point == "/home";
+                create_btrfs_subvolumes(cmd, &part_path, &part_subvols, &temp_mount, skip_home)?;
+                mount_btrfs_subvolumes(cmd, &part_path, &part_subvols, install_root)?;
+            } else {
+                // Non-btrfs (or plain-mount) partition.
+                let full_mount = format!("{}{}", install_root, mount_point);
+                if !cmd.is_dry_run() {
+                    std::fs::create_dir_all(&full_mount)?;
+                }
+                info!("Mounting {} to {}", part_path, full_mount);
+                cmd.run("mount", &[&part_path, &full_mount])?;
             }
-
-            info!("Mounting {} to {}", part_path, full_mount);
-            cmd.run("mount", &[&part_path, &full_mount])?;
         }
     }
 

--- a/src/install/fstab.rs
+++ b/src/install/fstab.rs
@@ -5,7 +5,7 @@ use crate::configure::encryption::LuksContainer;
 use crate::configure::swap::{swap_file_fstab_entry, SWAP_FILE_PATH};
 use crate::disk::detection::partition_path;
 use crate::disk::formatting::{get_partition_uuid, ZFS_BOOT_DATASET, ZFS_DATASETS};
-use crate::disk::layouts::{multi_volume_subvolumes, ComputedLayout};
+use crate::disk::layouts::{multi_volume_subvolumes, mount_point_to_subvol_name, ComputedLayout};
 use crate::disk::lvm::{lv_path, ThinVolumeDef};
 use crate::utils::command::CommandRunner;
 use crate::utils::error::Result;
@@ -259,10 +259,10 @@ fn generate_fstab_with_subvolumes(
         ));
     }
 
-    // Add other partitions (BOOT, EFI, swap, etc.)
+    // Add other partitions (BOOT, EFI, swap, and per-partition btrfs subvolumes).
     for part in &layout.partitions {
         if part.name == "ROOT" {
-            continue; // Already handled via subvolumes
+            continue; // Already handled via subvolumes above
         }
 
         let part_path = partition_path(device, part.number);
@@ -293,13 +293,29 @@ fn generate_fstab_with_subvolumes(
                 ));
             }
         } else if let Some(ref mount_point) = part.mount_point {
-            // Any remaining partition with a mount point is a regular data partition.
-            let (fstype, options) = fs_fstab_entry(filesystem);
-            let pass = fsck_pass(filesystem, mount_point);
-            content.push_str(&format!(
-                "\nUUID={}  {}  {}  {}  0  {}\n",
-                uuid, mount_point, fstype, options, pass
-            ));
+            if let Some(ref subvol_name) = part.subvolume_name {
+                // Btrfs data partition with its own dedicated subvolume.
+                content.push_str(&format!(
+                    "\n# {} partition (btrfs {} subvolume)\nUUID={}  {}  btrfs  subvol={},defaults,noatime,compress=zstd  0  0\n",
+                    part.name, subvol_name, uuid, mount_point, subvol_name
+                ));
+                // /var also hosts @log (→ /var/log) on the same btrfs filesystem.
+                if mount_point == "/var" {
+                    let log_subvol = mount_point_to_subvol_name("/var/log");
+                    content.push_str(&format!(
+                        "UUID={}  /var/log  btrfs  subvol={},defaults,noatime,compress=zstd  0  0\n",
+                        uuid, log_subvol
+                    ));
+                }
+            } else {
+                // Non-btrfs data partition or btrfs partition without a named subvolume.
+                let (fstype, options) = fs_fstab_entry(filesystem);
+                let pass = fsck_pass(filesystem, mount_point);
+                content.push_str(&format!(
+                    "\nUUID={}  {}  {}  {}  0  {}\n",
+                    uuid, mount_point, fstype, options, pass
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
When btrfs is selected as the data filesystem, subvolumes are now created
automatically on every data and boot partition—no opt-in checkbox or config
flag required.

Layout behaviour:
- Single-ROOT layout: ROOT gets the full standard set (@, @home, @usr,
  @var, @log) as before, unchanged.
- Multi-partition layout (default: ROOT + USR + VAR + HOME): each
  partition receives exactly one named subvolume (@, @usr, @var / @log,
  @home respectively).  The BOOT partition continues to receive @boot via
  the existing mount_boot_btrfs_subvolume path when boot_filesystem is
  btrfs (auto-derived from data filesystem).

Implementation:
- Add PartitionDef.subvolume_name: Option<String> field; set unconditionally
  for each non-root data partition in compute_layout_from_config() when
  filesystem == Btrfs.
- Add mount_point_to_subvol_name() helper: "/" → "@", "/usr" → "@usr", etc.
- compute_layout_from_config(): replace `use_subvolumes` flag check with
  `filesystem == Btrfs` so subvolumes are always applied.
- chroot.rs mount_partitions_with_subvolumes(): when a partition carries
  subvolume_name, call create_btrfs_subvolumes + mount_btrfs_subvolumes
  instead of a plain mount.  /var also creates @log for /var/log.
- fstab.rs generate_fstab_with_subvolumes(): emit subvol=@name fstab
  entries for partitions with subvolume_name; /var also emits @log entry.
- Config wizard: remove interactive use_subvolumes prompt; auto-set from
  filesystem type.
- GUI: remove subvolumes checkbox; auto-set when btrfs is chosen.

https://claude.ai/code/session_01BsBHh2v4RCYnuyC57vxsP2