### PR TITLE
Fix swap configuration for multi-volume encrypted layouts

### DIFF
--- a/src/config/deployment.rs
+++ b/src/config/deployment.rs
@@ -811,7 +811,11 @@ impl DeploymentConfig {
         println!("\n📦 Optional Package Collections\n");
 
         // GPU drivers (multi-select)
-        let gpu_vendors = [GpuDriverVendor::Nvidia, GpuDriverVendor::Amd, GpuDriverVendor::Intel];
+        let gpu_vendors = [
+            GpuDriverVendor::Nvidia,
+            GpuDriverVendor::Amd,
+            GpuDriverVendor::Intel,
+        ];
         let gpu_defaults = vec![false; gpu_vendors.len()];
         let gpu_selected = prompt_multi_select(
             "Video/Graphics Drivers (space to toggle, enter to confirm)",
@@ -830,8 +834,12 @@ impl DeploymentConfig {
         let install_gaming = prompt_confirm("Install Gaming packages (Steam, gamescope)?", false)?;
 
         // Session switching (only if gaming + desktop are both selected)
-        let install_session_switching = if install_gaming && environment != DesktopEnvironment::None {
-            prompt_confirm("Enable session switching (Game Mode ↔ Desktop via greetd)?", true)?
+        let install_session_switching = if install_gaming && environment != DesktopEnvironment::None
+        {
+            prompt_confirm(
+                "Enable session switching (Game Mode ↔ Desktop via greetd)?",
+                true,
+            )?
         } else {
             false
         };
@@ -841,12 +849,18 @@ impl DeploymentConfig {
 
         // Btrfs tools (snapper + btrfs-assistant) via yay — only when btrfs + yay
         let install_btrfs_tools = if install_yay && filesystem == Filesystem::Btrfs {
-            prompt_confirm("Install btrfs snapshot tools (snapper, btrfs-assistant) via yay?", false)?
+            prompt_confirm(
+                "Install btrfs snapshot tools (snapper, btrfs-assistant) via yay?",
+                false,
+            )?
         } else {
             false
         };
 
-        let install_modular = prompt_confirm("Install Modular mod manager? (CLI + GUI for NexusMods, GameBanana)", false)?;
+        let install_modular = prompt_confirm(
+            "Install Modular mod manager? (CLI + GUI for NexusMods, GameBanana)",
+            false,
+        )?;
 
         // sysctl gaming tweaks (standalone — no prerequisites)
         let sysctl_gaming_tweaks = prompt_confirm(
@@ -1074,7 +1088,11 @@ impl DeploymentConfig {
 
         // preserve_home without a dedicated /home partition requires subvolumes
         // (there must be an @home subvolume to preserve).
-        let has_home_partition = self.disk.partitions.iter().any(|p| p.mount_point == "/home");
+        let has_home_partition = self
+            .disk
+            .partitions
+            .iter()
+            .any(|p| p.mount_point == "/home");
         if self.disk.preserve_home && !has_home_partition && !self.disk.use_subvolumes {
             return Err(DeploytixError::ValidationError(
                 "preserve_home requires either a /home partition or use_subvolumes = true"
@@ -1105,8 +1123,7 @@ impl DeploymentConfig {
         }
 
         // zram_percent must be 1–100 when ZRAM is used
-        if (self.disk.swap_type == SwapType::ZramOnly
-            || self.disk.swap_type == SwapType::FileZram)
+        if (self.disk.swap_type == SwapType::ZramOnly || self.disk.swap_type == SwapType::FileZram)
             && (self.disk.zram_percent == 0 || self.disk.zram_percent > 100)
         {
             return Err(DeploytixError::ValidationError(format!(

--- a/src/configure/bootloader.rs
+++ b/src/configure/bootloader.rs
@@ -155,7 +155,13 @@ fn install_grub_with_layout(
         } else {
             get_luks_uuid(&luks_device)?
         };
-        configure_grub_defaults_lvm_thin(cmd, config, &luks_uuid, install_root, swap_uuid.as_deref())?;
+        configure_grub_defaults_lvm_thin(
+            cmd,
+            config,
+            &luks_uuid,
+            install_root,
+            swap_uuid.as_deref(),
+        )?;
     } else if config.disk.use_lvm_thin {
         // LVM thin without encryption: root is on an LVM LV
         let vg_name = &config.disk.lvm_vg_name;
@@ -544,6 +550,7 @@ echo "GRUB reinstallation complete"
 /// Configure GRUB defaults
 /// For encrypted systems, pass luks_uuid and mapper_name
 /// uses_subvolumes indicates if the layout uses btrfs subvolumes (for rootflags)
+#[allow(clippy::too_many_arguments)]
 fn configure_grub_defaults(
     cmd: &CommandRunner,
     config: &DeploymentConfig,

--- a/src/configure/greetd.rs
+++ b/src/configure/greetd.rs
@@ -39,34 +39,35 @@ pub fn configure_greetd(
     // Determine session command based on desktop environment
     let session_cmd = get_session_command(&config.desktop.environment);
 
-    let config_content = if config.packages.install_session_switching && config.packages.install_gaming {
-        // Session switching mode: greetd auto-logins the user into
-        // deploytix-session-manager, which handles the gamescope ↔ desktop
-        // loop internally via a sentinel file.
-        format!(
-            r#"[terminal]
+    let config_content =
+        if config.packages.install_session_switching && config.packages.install_gaming {
+            // Session switching mode: greetd auto-logins the user into
+            // deploytix-session-manager, which handles the gamescope ↔ desktop
+            // loop internally via a sentinel file.
+            format!(
+                r#"[terminal]
 vt = 1
 
 [default_session]
 command = "deploytix-session-manager"
 user = "{user}"
 "#,
-            user = username,
-        )
-    } else {
-        // Standard mode: desktop session as default
-        format!(
-            r#"[terminal]
+                user = username,
+            )
+        } else {
+            // Standard mode: desktop session as default
+            format!(
+                r#"[terminal]
 vt = 1
 
 [default_session]
 command = "{session}"
 user = "{user}"
 "#,
-            session = session_cmd,
-            user = username,
-        )
-    };
+                session = session_cmd,
+                user = username,
+            )
+        };
 
     let greetd_dir = format!("{}/etc/greetd", install_root);
     fs::create_dir_all(&greetd_dir)?;

--- a/src/configure/hooks.rs
+++ b/src/configure/hooks.rs
@@ -441,9 +441,7 @@ fn generate_mountcrypt_hook(config: &DeploymentConfig, layout: &ComputedLayout) 
 
     // Remaining encrypted volumes
     for part in &luks_data_parts {
-        if part.mount_point.as_deref() == Some("/")
-            || part.name.eq_ignore_ascii_case("ROOT")
-        {
+        if part.mount_point.as_deref() == Some("/") || part.name.eq_ignore_ascii_case("ROOT") {
             continue; // Already handled above
         }
         let mp = match part.mount_point.as_deref() {
@@ -464,7 +462,11 @@ fn generate_mountcrypt_hook(config: &DeploymentConfig, layout: &ComputedLayout) 
             let svols = multi_volume_subvolumes(&title);
             for sv in &svols {
                 // /usr failure is a hard error; everything else is a warning
-                let severity = if sv.mount_point == "/usr" { "ERROR" } else { "WARNING" };
+                let severity = if sv.mount_point == "/usr" {
+                    "ERROR"
+                } else {
+                    "WARNING"
+                };
                 let fail_action = if sv.mount_point == "/usr" {
                     "        ret=1".to_string()
                 } else {

--- a/src/configure/mkinitcpio.rs
+++ b/src/configure/mkinitcpio.rs
@@ -144,7 +144,12 @@ pub fn construct_hooks(config: &DeploymentConfig) -> Vec<String> {
         hooks.push("filesystems".to_string());
 
         // Separate /usr partition requires the usr hook for early mount
-        if config.disk.partitions.iter().any(|p| p.mount_point == "/usr") {
+        if config
+            .disk
+            .partitions
+            .iter()
+            .any(|p| p.mount_point == "/usr")
+        {
             hooks.push("usr".to_string());
         }
 

--- a/src/configure/packages.rs
+++ b/src/configure/packages.rs
@@ -85,7 +85,10 @@ pub fn install_gpu_drivers(
     info!("Installing GPU driver packages: {}", packages.join(", "));
 
     if cmd.is_dry_run() {
-        println!("  [dry-run] Would install GPU driver packages: {:?}", packages);
+        println!(
+            "  [dry-run] Would install GPU driver packages: {:?}",
+            packages
+        );
         return Ok(());
     }
 
@@ -127,8 +130,8 @@ fn ensure_arch_repos_in_chroot(cmd: &CommandRunner, install_root: &str) -> Resul
 
     // Append [extra] to the chroot's pacman.conf if not already present.
     let chroot_pacman_conf = format!("{}/etc/pacman.conf", install_root);
-    let conf_content =
-        std::fs::read_to_string(&chroot_pacman_conf).map_err(crate::utils::error::DeploytixError::Io)?;
+    let conf_content = std::fs::read_to_string(&chroot_pacman_conf)
+        .map_err(crate::utils::error::DeploytixError::Io)?;
 
     if !conf_content.lines().any(|line| line.trim() == "[extra]") {
         info!("Adding Arch [extra] repository to chroot pacman.conf");
@@ -270,8 +273,14 @@ pub fn install_gaming_packages(
 
     if cmd.is_dry_run() {
         println!("  [dry-run] Would enable [lib32] repository");
-        println!("  [dry-run] Would install lib32 Vulkan drivers: {:?}", lib32_vulkan);
-        println!("  [dry-run] Would install gaming packages: {:?}", GAMING_PACKAGES);
+        println!(
+            "  [dry-run] Would install lib32 Vulkan drivers: {:?}",
+            lib32_vulkan
+        );
+        println!(
+            "  [dry-run] Would install gaming packages: {:?}",
+            GAMING_PACKAGES
+        );
         return Ok(());
     }
 
@@ -312,10 +321,16 @@ pub fn install_yay(
     }
 
     let username = &config.user.name;
-    info!("Installing yay AUR helper (building from source as {})", username);
+    info!(
+        "Installing yay AUR helper (building from source as {})",
+        username
+    );
 
     if cmd.is_dry_run() {
-        println!("  [dry-run] Would install go and build yay from source as {}", username);
+        println!(
+            "  [dry-run] Would install go and build yay from source as {}",
+            username
+        );
         return Ok(());
     }
 
@@ -454,8 +469,14 @@ pub fn install_autostart_entries(
     info!("Installing autostart entries for user {}", username);
 
     if cmd.is_dry_run() {
-        println!("  [dry-run] Would install audio-startup to /home/{}/.local/bin/", username);
-        println!("  [dry-run] Would install autostart .desktop entries to /home/{}/.config/autostart/", username);
+        println!(
+            "  [dry-run] Would install audio-startup to /home/{}/.local/bin/",
+            username
+        );
+        println!(
+            "  [dry-run] Would install autostart .desktop entries to /home/{}/.config/autostart/",
+            username
+        );
         return Ok(());
     }
 
@@ -634,11 +655,7 @@ pub fn install_hhd(
 }
 
 /// Write the HHD service file for the configured init system.
-fn write_hhd_service(
-    config: &DeploymentConfig,
-    install_root: &str,
-    username: &str,
-) -> Result<()> {
+fn write_hhd_service(config: &DeploymentConfig, install_root: &str, username: &str) -> Result<()> {
     use crate::config::InitSystem;
 
     match config.system.init {

--- a/src/configure/session_switching.rs
+++ b/src/configure/session_switching.rs
@@ -103,7 +103,10 @@ fn install_gamescope_session(
     info!("Building gamescope-session-git from AUR as {}", username);
 
     if cmd.is_dry_run() {
-        println!("  [dry-run] Would build gamescope-session-git from AUR as {}", username);
+        println!(
+            "  [dry-run] Would build gamescope-session-git from AUR as {}",
+            username
+        );
         return Ok(());
     }
 

--- a/src/configure/swap.rs
+++ b/src/configure/swap.rs
@@ -106,7 +106,7 @@ echo 1 > /sys/block/zram0/reset 2>/dev/null
     // Enable the service by creating a symlink in the default runsvdir
     let link_dir = format!("{}/etc/runit/runsvdir/default", install_root);
     fs::create_dir_all(&link_dir)?;
-    std::os::unix::fs::symlink(&format!("/etc/runit/sv/zram"), &format!("{}/zram", link_dir))?;
+    std::os::unix::fs::symlink("/etc/runit/sv/zram", format!("{}/zram", link_dir))?;
 
     info!("Created and enabled runit ZRAM service at {}", sv_dir);
     Ok(())
@@ -162,7 +162,7 @@ stop() {{
     // Enable the service in the default runlevel
     let runlevel_dir = format!("{}/etc/runlevels/default", install_root);
     fs::create_dir_all(&runlevel_dir)?;
-    std::os::unix::fs::symlink(&format!("/etc/init.d/zram"), &format!("{}/zram", runlevel_dir))?;
+    std::os::unix::fs::symlink("/etc/init.d/zram", format!("{}/zram", runlevel_dir))?;
 
     info!("Created and enabled OpenRC ZRAM service at {}", script_path);
     Ok(())
@@ -288,7 +288,7 @@ depends-on = mount.local
     // Enable the service by creating a symlink in boot.d
     let boot_d = format!("{}/etc/dinit.d/boot.d", install_root);
     fs::create_dir_all(&boot_d)?;
-    std::os::unix::fs::symlink(&format!("/etc/dinit.d/zram"), &format!("{}/zram", boot_d))?;
+    std::os::unix::fs::symlink("/etc/dinit.d/zram", format!("{}/zram", boot_d))?;
 
     info!("Created and enabled dinit ZRAM service at {}", service_path);
     Ok(())

--- a/src/configure/users.rs
+++ b/src/configure/users.rs
@@ -121,7 +121,10 @@ fn configure_bashrc_path(install_root: &str, username: &str) -> Result<()> {
     content.push_str(snippet);
     fs::write(&bashrc_path, content)?;
 
-    info!("Added ~/.local/bin PATH export to /home/{}/.bashrc", username);
+    info!(
+        "Added ~/.local/bin PATH export to /home/{}/.bashrc",
+        username
+    );
     Ok(())
 }
 

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -219,7 +219,13 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
 
 /// Filename prefixes (with trailing dash) for package archives that
 /// belong to the custom [deploytix] repository.
-const CUSTOM_PKG_PREFIXES: &[&str] = &["deploytix-git-", "deploytix-gui-git-", "tkg-gui-git-", "modular-git-", "unl0kr-"];
+const CUSTOM_PKG_PREFIXES: &[&str] = &[
+    "deploytix-git-",
+    "deploytix-gui-git-",
+    "tkg-gui-git-",
+    "modular-git-",
+    "unl0kr-",
+];
 
 /// Packages from the [deploytix] repo that are in the basestrap list
 /// and must be resolvable.
@@ -253,11 +259,7 @@ const ARCH_MIRRORLIST_PATH: &str = "/etc/pacman.d/mirrorlist-arch";
 /// `[deploytix]` repository section.
 fn pacman_conf_has_deploytix_repo() -> bool {
     std::fs::read_to_string("/etc/pacman.conf")
-        .map(|contents| {
-            contents
-                .lines()
-                .any(|line| line.trim() == "[deploytix]")
-        })
+        .map(|contents| contents.lines().any(|line| line.trim() == "[deploytix]"))
         .unwrap_or(false)
 }
 
@@ -366,7 +368,8 @@ fn locate_prebuilt_packages() -> Vec<PathBuf> {
         if let Some(repo_root) = exe
             .parent() // target/release/
             .and_then(|p| p.parent()) // target/
-            .and_then(|p| p.parent()) // repo root
+            .and_then(|p| p.parent())
+        // repo root
         {
             search_dirs.push(repo_root.join("pkg"));
             // Sibling tkg-gui, Modular-1, and unl0kr repos.
@@ -462,8 +465,7 @@ fn create_temp_repo(cmd: &CommandRunner, packages: &[PathBuf]) -> Result<()> {
 /// Write a temporary `pacman.conf` that extends the system config with
 /// a `[deploytix]` repo section.  Returns the path to the temp file.
 fn write_custom_pacman_conf(repo_dir: &str) -> Result<Option<String>> {
-    let system_conf =
-        std::fs::read_to_string("/etc/pacman.conf").map_err(DeploytixError::Io)?;
+    let system_conf = std::fs::read_to_string("/etc/pacman.conf").map_err(DeploytixError::Io)?;
 
     let custom = format!(
         "{}\n\n\
@@ -564,28 +566,20 @@ fn conf_has_arch_extra(conf: &str) -> bool {
 /// in the Artix repositories.  If the effective config already
 /// contains `[extra]` this is a no-op; otherwise a custom pacman.conf
 /// is written (or updated) with the repo appended.
-fn ensure_arch_repos(
-    existing_conf: Option<String>,
-    cmd: &CommandRunner,
-) -> Result<Option<String>> {
+fn ensure_arch_repos(existing_conf: Option<String>, cmd: &CommandRunner) -> Result<Option<String>> {
     if cmd.is_dry_run() {
         return Ok(existing_conf);
     }
 
-    let conf_path = existing_conf
-        .as_deref()
-        .unwrap_or("/etc/pacman.conf");
+    let conf_path = existing_conf.as_deref().unwrap_or("/etc/pacman.conf");
 
-    let conf_content =
-        std::fs::read_to_string(conf_path).map_err(DeploytixError::Io)?;
+    let conf_content = std::fs::read_to_string(conf_path).map_err(DeploytixError::Io)?;
 
     if conf_has_arch_extra(&conf_content) {
         return Ok(existing_conf);
     }
 
-    info!(
-        "Arch [extra] repository not configured; adding it"
-    );
+    info!("Arch [extra] repository not configured; adding it");
 
     let mirror_entry = if Path::new(ARCH_MIRRORLIST_PATH).exists() {
         format!("Include = {}", ARCH_MIRRORLIST_PATH)

--- a/src/install/chroot.rs
+++ b/src/install/chroot.rs
@@ -32,7 +32,14 @@ pub fn mount_partitions_preserve(
     preserve_home: bool,
     boot_filesystem: &Filesystem,
 ) -> Result<()> {
-    mount_partitions_inner(cmd, device, layout, install_root, preserve_home, boot_filesystem)
+    mount_partitions_inner(
+        cmd,
+        device,
+        layout,
+        install_root,
+        preserve_home,
+        boot_filesystem,
+    )
 }
 
 fn mount_partitions_inner(
@@ -372,4 +379,3 @@ pub fn unmount_all(cmd: &CommandRunner, install_root: &str) -> Result<()> {
 
     Ok(())
 }
-

--- a/src/install/fstab.rs
+++ b/src/install/fstab.rs
@@ -5,7 +5,7 @@ use crate::configure::encryption::LuksContainer;
 use crate::configure::swap::{swap_file_fstab_entry, SWAP_FILE_PATH};
 use crate::disk::detection::partition_path;
 use crate::disk::formatting::{get_partition_uuid, ZFS_BOOT_DATASET, ZFS_DATASETS};
-use crate::disk::layouts::{multi_volume_subvolumes, mount_point_to_subvol_name, ComputedLayout};
+use crate::disk::layouts::{mount_point_to_subvol_name, multi_volume_subvolumes, ComputedLayout};
 use crate::disk::lvm::{lv_path, ThinVolumeDef};
 use crate::utils::command::CommandRunner;
 use crate::utils::error::Result;
@@ -21,11 +21,7 @@ use tracing::info;
 fn boot_fs_fstab_entry(boot_filesystem: &Filesystem) -> (&'static str, &'static str, u8) {
     match boot_filesystem {
         Filesystem::Ext4 => ("ext4", "defaults,noatime", 0),
-        Filesystem::Btrfs => (
-            "btrfs",
-            "subvol=@boot,defaults,noatime,compress=zstd",
-            0,
-        ),
+        Filesystem::Btrfs => ("btrfs", "subvol=@boot,defaults,noatime,compress=zstd", 0),
         Filesystem::Xfs => ("xfs", "defaults,noatime", 0),
         Filesystem::F2fs => ("f2fs", "defaults,noatime", 0),
         Filesystem::Zfs => ("zfs", "zfsutil,defaults,noatime", 0),
@@ -275,7 +271,7 @@ fn generate_fstab_with_subvolumes(
             ));
         } else if part.is_efi {
             content.push_str(&format!(
-            "\n# EFI System Partition\nUUID={}  /boot/efi  vfat  umask=0077,defaults  0  0\n",
+                "\n# EFI System Partition\nUUID={}  /boot/efi  vfat  umask=0077,defaults  0  0\n",
                 uuid
             ));
         } else if part.is_boot_fs {
@@ -335,15 +331,27 @@ fn generate_fstab_with_subvolumes(
 ///
 /// Creates entries for separate encrypted partitions (ROOT, USR, VAR, HOME)
 /// mounted from /dev/mapper/Crypt-* devices.
-pub fn generate_fstab_multi_volume(
-    cmd: &CommandRunner,
-    containers: &[LuksContainer],
-    device: &str,
-    layout: &ComputedLayout,
-    filesystem: &Filesystem,
-    boot_filesystem: &Filesystem,
-    install_root: &str,
-) -> Result<()> {
+/// Parameters for multi-volume encrypted fstab generation
+pub struct MultiVolumeFstabParams<'a> {
+    pub cmd: &'a CommandRunner,
+    pub containers: &'a [LuksContainer],
+    pub device: &'a str,
+    pub layout: &'a ComputedLayout,
+    pub filesystem: &'a Filesystem,
+    pub boot_filesystem: &'a Filesystem,
+    pub swap_type: &'a SwapType,
+    pub install_root: &'a str,
+}
+
+pub fn generate_fstab_multi_volume(params: &MultiVolumeFstabParams) -> Result<()> {
+    let cmd = params.cmd;
+    let containers = params.containers;
+    let device = params.device;
+    let layout = params.layout;
+    let filesystem = params.filesystem;
+    let boot_filesystem = params.boot_filesystem;
+    let swap_type = params.swap_type;
+    let install_root = params.install_root;
     info!(
         "Generating /etc/fstab for {} encrypted volumes",
         containers.len()
@@ -412,16 +420,31 @@ pub fn generate_fstab_multi_volume(
         }
     }
 
-    // Add SWAP partition
-    let swap_part = layout.partitions.iter().find(|p| p.is_swap);
-    if let Some(swap) = swap_part {
-        let swap_device = partition_path(device, swap.number);
-        let swap_uuid = get_partition_uuid(&swap_device)?;
-        content.push_str(&format!(
-            "# Swap partition\n\
-             UUID={}  none  swap  defaults  0  0\n\n",
-            swap_uuid
-        ));
+    // Add swap based on swap_type
+    match swap_type {
+        SwapType::Partition => {
+            let swap_part = layout.partitions.iter().find(|p| p.is_swap);
+            if let Some(swap) = swap_part {
+                let swap_device = partition_path(device, swap.number);
+                let swap_uuid = get_partition_uuid(&swap_device)?;
+                content.push_str(&format!(
+                    "# Swap partition\n\
+                     UUID={}  none  swap  defaults  0  0\n\n",
+                    swap_uuid
+                ));
+            }
+        }
+        SwapType::FileZram => {
+            content.push_str(&format!(
+                "# Swap file (ZRAM provides additional compressed swap)\n\
+                 {}  none  swap  defaults  0  0\n\n",
+                SWAP_FILE_PATH
+            ));
+        }
+        SwapType::ZramOnly => {
+            // No fstab entry needed - ZRAM is configured via service
+            content.push_str("# Swap: ZRAM only (configured via service)\n\n");
+        }
     }
 
     // Add BOOT partition

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -13,15 +13,15 @@ use crate::disk::formatting::{
     format_efi, format_swap, mount_btrfs_subvolumes,
 };
 use crate::disk::layouts::{
-    compute_layout_from_config, get_luks_partitions, multi_volume_subvolumes,
-    print_layout_summary, ComputedLayout,
+    compute_layout_from_config, get_luks_partitions, multi_volume_subvolumes, print_layout_summary,
+    ComputedLayout,
 };
 use crate::disk::lvm::{self, lv_path, ThinVolumeDef};
 use crate::disk::partitioning::apply_partitions;
 use crate::install::crypttab::generate_crypttab_multi_volume;
 use crate::install::fstab::{
     append_swap_file_entry, generate_fstab_lvm_thin, generate_fstab_multi_volume,
-    LvmThinFstabParams,
+    LvmThinFstabParams, MultiVolumeFstabParams,
 };
 use crate::install::{
     generate_fstab, mount_boot_btrfs_subvolume, mount_partitions, mount_partitions_preserve,
@@ -277,7 +277,10 @@ impl Installer {
 
         // Phase 5.4: Btrfs snapshot tools via yay (after yay, requires btrfs)
         if self.config.packages.install_btrfs_tools {
-            self.report_progress(0.88, "Installing btrfs snapshot tools (snapper, btrfs-assistant)...");
+            self.report_progress(
+                0.88,
+                "Installing btrfs snapshot tools (snapper, btrfs-assistant)...",
+            );
             self.install_btrfs_tools()?;
         }
 
@@ -1129,6 +1132,15 @@ impl Installer {
         self.cmd.run("mount", &[&efi_device, &efi_mount])?;
         info!("Mounted {} to {}", efi_device, efi_mount);
 
+        // Enable swap partitions
+        for part in &layout.partitions {
+            if part.is_swap {
+                let swap_device = partition_path(&self.config.disk.device, part.number);
+                info!("Enabling swap on {}", swap_device);
+                self.cmd.run("swapon", &[&swap_device])?;
+            }
+        }
+
         Ok(())
     }
 
@@ -1181,12 +1193,7 @@ impl Installer {
                 temp_mount,
                 preserve,
             )?;
-            mount_btrfs_subvolumes(
-                &self.cmd,
-                &container.mapped_path,
-                &svols,
-                INSTALL_ROOT,
-            )?;
+            mount_btrfs_subvolumes(&self.cmd, &container.mapped_path, &svols, INSTALL_ROOT)?;
         }
 
         Ok(())
@@ -1261,15 +1268,16 @@ impl Installer {
 
         let layout = self.layout.as_ref().unwrap();
 
-        generate_fstab_multi_volume(
-            &self.cmd,
-            &self.luks_containers,
-            &self.config.disk.device,
+        generate_fstab_multi_volume(&MultiVolumeFstabParams {
+            cmd: &self.cmd,
+            containers: &self.luks_containers,
+            device: &self.config.disk.device,
             layout,
-            &self.config.disk.filesystem,
-            &self.config.disk.boot_filesystem,
-            INSTALL_ROOT,
-        )
+            filesystem: &self.config.disk.filesystem,
+            boot_filesystem: &self.config.disk.boot_filesystem,
+            swap_type: &self.config.disk.swap_type,
+            install_root: INSTALL_ROOT,
+        })
     }
 
     /// Generate crypttab for multi-volume encrypted system
@@ -1626,7 +1634,8 @@ impl Installer {
                 "none".to_string()
             };
 
-            let lvm_options = crate::install::crypttab::crypttab_options_pub(self.config.disk.integrity);
+            let lvm_options =
+                crate::install::crypttab::crypttab_options_pub(self.config.disk.integrity);
             let mut content = format!(
                 "# /etc/crypttab: LUKS containers for LVM thin provisioning\n\
                  # <target name>  <source device>  <key file>  <options>\n\

--- a/src/utils/prompt.rs
+++ b/src/utils/prompt.rs
@@ -84,7 +84,11 @@ pub fn prompt_optional(prompt: &str) -> Result<Option<String>> {
 }
 
 /// Prompt for multiple selections from a list (checkboxes)
-pub fn prompt_multi_select<T: ToString>(prompt: &str, items: &[T], defaults: &[bool]) -> Result<Vec<usize>> {
+pub fn prompt_multi_select<T: ToString>(
+    prompt: &str,
+    items: &[T],
+    defaults: &[bool],
+) -> Result<Vec<usize>> {
     let theme = ColorfulTheme::default();
     MultiSelect::with_theme(&theme)
         .with_prompt(prompt)


### PR DESCRIPTION
- Add missing swapon call in mount_multi_volume_partitions() — swap
  partitions were formatted but never activated during encrypted installs
- Extend generate_fstab_multi_volume() to handle all SwapType variants
  (Partition, FileZram, ZramOnly) instead of only Partition, matching
  the existing generate_fstab_lvm_thin() behavior
- Refactor generate_fstab_multi_volume() to use a params struct to
  satisfy clippy::too_many_arguments after adding the swap_type param
- Fix clippy warnings in swap.rs (needless borrows in symlink calls)
  and bootloader.rs (too_many_arguments on configure_grub_defaults)

https://claude.ai/code/session_011GDTBcj4UpWymQahMuM8La