### PR TITLE
fix(disk): use 'p' separator for NBD and other digit-terminated devices

### DIFF
--- a/src/disk/detection.rs
+++ b/src/disk/detection.rs
@@ -242,13 +242,24 @@ pub fn get_device_info(device_path: &str) -> Result<BlockDevice> {
     })
 }
 
-/// Get the partition naming prefix for a device
-/// e.g., /dev/sda -> /dev/sda, /dev/nvme0n1 -> /dev/nvme0n1p
+/// Get the partition naming prefix for a device.
+///
+/// Mirrors the kernel's partition-naming rule (see `disk_name()` in
+/// `block/genhd.c`): if the disk name ends in a digit, append a `p`
+/// separator so the partition number can't be concatenated ambiguously.
+///
+/// Examples:
+///   /dev/sda      -> /dev/sda        (sda1, sda2, ...)
+///   /dev/vda      -> /dev/vda        (vda1, vda2, ...)
+///   /dev/nvme0n1  -> /dev/nvme0n1p   (nvme0n1p1, ...)
+///   /dev/mmcblk0  -> /dev/mmcblk0p   (mmcblk0p1, ...)
+///   /dev/loop0    -> /dev/loop0p     (loop0p1, ...)
+///   /dev/nbd0     -> /dev/nbd0p      (nbd0p1, ...)
+///   /dev/md0      -> /dev/md0p       (md0p1, ...)
 pub fn partition_prefix(device: &str) -> String {
-    if device.contains("nvme") || device.contains("mmcblk") || device.contains("loop") {
-        format!("{}p", device)
-    } else {
-        device.to_string()
+    match device.chars().last() {
+        Some(c) if c.is_ascii_digit() => format!("{}p", device),
+        _ => device.to_string(),
     }
 }
 
@@ -324,6 +335,36 @@ mod tests {
     #[test]
     fn partition_path_mmcblk_uses_p_separator() {
         assert_eq!(partition_path("/dev/mmcblk0", 1), "/dev/mmcblk0p1");
+    }
+
+    #[test]
+    fn partition_prefix_appends_p_for_nbd_device() {
+        // Regression: NBD devices end in a digit, so they require the `p`
+        // separator just like nvme/mmcblk/loop.  Previously the installer
+        // built `/dev/nbd03` for partition 3 on /dev/nbd0 and crashed with
+        // `Device /dev/nbd03 does not exist or access denied.`
+        assert_eq!(partition_prefix("/dev/nbd0"), "/dev/nbd0p");
+        assert_eq!(partition_prefix("/dev/nbd15"), "/dev/nbd15p");
+    }
+
+    #[test]
+    fn partition_path_nbd_uses_p_separator() {
+        assert_eq!(partition_path("/dev/nbd0", 1), "/dev/nbd0p1");
+        assert_eq!(partition_path("/dev/nbd0", 3), "/dev/nbd0p3");
+        assert_eq!(partition_path("/dev/nbd15", 2), "/dev/nbd15p2");
+    }
+
+    #[test]
+    fn partition_prefix_appends_p_for_md_device() {
+        assert_eq!(partition_prefix("/dev/md0"), "/dev/md0p");
+        assert_eq!(partition_prefix("/dev/md127"), "/dev/md127p");
+    }
+
+    #[test]
+    fn partition_path_multi_digit_partition_number_on_nbd() {
+        // Make sure the `p` separator keeps partition numbers unambiguous
+        // even with two-digit partition numbers.
+        assert_eq!(partition_path("/dev/nbd1", 10), "/dev/nbd1p10");
     }
 
     // ── is_physical_disk ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Installing to a VDI mounted as a network block device fails with:

```
Failed to format LUKS container: Device /dev/nbd03 does not exist or access denied.
```

`/dev/nbd03` doesn't exist — Linux names NBD partitions `/dev/nbd0p1`, `/dev/nbd0p2`, `/dev/nbd0p3`, ... The bug is in `partition_prefix()` in `src/disk/detection.rs`: it only appends the `p` separator when the device name contains `nvme`, `mmcblk`, or `loop`. NBD falls through to the `sda`-style path and `format!("{}{}", "/dev/nbd0", 3)` produces `/dev/nbd03`, which cryptsetup then (correctly) refuses because it doesn't exist.

## Fix

Switch to the kernel's actual partition-naming rule (`disk_name()` in `block/genhd.c`): append `p` whenever the disk name ends in a digit. This is what `util-linux` / `partx` / `kpartx` effectively do, and it also correctly handles `md0`, `dm-0`, and any future digit-terminated device class without needing another substring patch.

```rust
pub fn partition_prefix(device: &str) -> String {
    match device.chars().last() {
        Some(c) if c.is_ascii_digit() => format!("{}p", device),
        _ => device.to_string(),
    }
}
```

## Tests

Added regression tests for:
- `/dev/nbd0` and `/dev/nbd15` → `p` separator
- `/dev/md0` and `/dev/md127` → `p` separator
- Multi-digit partition numbers on NBD (`/dev/nbd1` part 10 → `/dev/nbd1p10`) — extra insurance against the ambiguity the `p` separator is meant to prevent

All 73 existing tests still pass. `partprobe` + `udevadm settle` are already called after `sfdisk` in `src/disk/partitioning.rs`, so no changes are needed on the kernel-reread path.

## Test plan

1. `qemu-nbd -c /dev/nbd0 disk.vdi`
2. Run the installer against `/dev/nbd0` with LUKS enabled
3. Partitioning, LUKS format, and bootloader install should all use `/dev/nbd0pN` paths