### PR TITLE
chore: remove unl0kr from Deploytix

### DIFF
--- a/iso/build-deploytix-iso.sh
+++ b/iso/build-deploytix-iso.sh
@@ -49,8 +49,6 @@ MODULAR_REPO_URL="https://github.com/MasterGenotype/Modular-1.git"
 MODULAR_LOCAL_DIR=""   # Resolved to sibling repo if present
 MODULAR_CLONE_DIR=""
 MODULAR_PKG_DIR=""
-UNL0KR_LOCAL_DIR=""    # Resolved to sibling unl0kr repo if present
-UNL0KR_PKG_DIR=""
 
 # ── Usage ────────────────────────────────────────────────────────────────────
 usage() {
@@ -132,12 +130,6 @@ resolve_paths() {
         MODULAR_PKG_DIR="${MODULAR_LOCAL_DIR}/pkg"
     else
         MODULAR_PKG_DIR="${MODULAR_CLONE_DIR}/pkg"
-    fi
-    UNL0KR_LOCAL_DIR="$(dirname "${REPO_ROOT}")/unl0kr"
-    if [[ -d "${UNL0KR_LOCAL_DIR}/pkg" && -f "${UNL0KR_LOCAL_DIR}/pkg/PKGBUILD" ]]; then
-        UNL0KR_PKG_DIR="${UNL0KR_LOCAL_DIR}/pkg"
-    else
-        UNL0KR_PKG_DIR=""
     fi
 }
 
@@ -288,12 +280,9 @@ build_packages() {
         if [[ -n "${MODULAR_PKG_DIR}" && -d "${MODULAR_PKG_DIR}" ]]; then
             count=$(( count + $(find "${MODULAR_PKG_DIR}" -maxdepth 1 -name '*.pkg.tar.zst' 2>/dev/null | wc -l) ))
         fi
-        if [[ -n "${UNL0KR_PKG_DIR}" && -d "${UNL0KR_PKG_DIR}" ]]; then
-            count=$(( count + $(find "${UNL0KR_PKG_DIR}" -maxdepth 1 -name '*.pkg.tar.zst' 2>/dev/null | wc -l) ))
-        fi
 
         if (( count == 0 )); then
-            die "No .pkg.tar.zst found in ${PKG_DIR}/, ${TKG_GUI_PKG_DIR}/, ${MODULAR_PKG_DIR}/, or ${UNL0KR_PKG_DIR}/ and -s (skip rebuild) was set"
+            die "No .pkg.tar.zst found in ${PKG_DIR}/, ${TKG_GUI_PKG_DIR}/, or ${MODULAR_PKG_DIR}/ and -s (skip rebuild) was set"
         fi
 
         msg "Skipping package build (-s); reusing existing packages"
@@ -404,7 +393,7 @@ create_local_repo() {
     local pkg_count=0
     local src_dir pkg
 
-    for src_dir in "${PKG_DIR}" "${TKG_GUI_PKG_DIR}" "${MODULAR_PKG_DIR}" "${UNL0KR_PKG_DIR}"; do
+    for src_dir in "${PKG_DIR}" "${TKG_GUI_PKG_DIR}" "${MODULAR_PKG_DIR}"; do
         [[ -d "$src_dir" ]] || continue
         for pkg in "${src_dir}"/*.pkg.tar.zst; do
             [[ -f "$pkg" ]] || continue
@@ -581,7 +570,7 @@ generate_gui_profile() {
 
     cp "$de_profile" "$dest/profile.yaml"
 
-    yq -i '.livefs.packages += ["deploytix-git", "deploytix-gui-git", "tkg-gui-git", "unl0kr"]' "$dest/profile.yaml"
+    yq -i '.livefs.packages += ["deploytix-git", "deploytix-gui-git", "tkg-gui-git"]' "$dest/profile.yaml"
     yq -i '.livefs.packages -= ["calamares-extensions"]' "$dest/profile.yaml"
 
     msg2 "GUI profile generated (${BASE_DE_PROFILE} + deploytix)"
@@ -605,7 +594,7 @@ embed_live_repo() {
     local pkg_count=0
     local src_dir pkg
 
-    for src_dir in "${PKG_DIR}" "${TKG_GUI_PKG_DIR}" "${MODULAR_PKG_DIR}" "${UNL0KR_PKG_DIR}"; do
+    for src_dir in "${PKG_DIR}" "${TKG_GUI_PKG_DIR}" "${MODULAR_PKG_DIR}"; do
         [[ -d "$src_dir" ]] || continue
         for pkg in "${src_dir}"/*.pkg.tar.zst; do
             [[ -f "$pkg" ]] || continue

--- a/iso/profile/deploytix/profile.yaml
+++ b/iso/profile/deploytix/profile.yaml
@@ -45,6 +45,5 @@ livefs:
   packages:
     - deploytix-git
     - tkg-gui-git
-    - unl0kr
     - dosfstools
     - artools

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -162,7 +162,6 @@ pub fn build_package_list(config: &DeploymentConfig) -> Vec<String> {
     // Encryption tools (if enabled)
     if config.disk.encryption {
         packages.push("cryptsetup".to_string());
-        packages.push("unl0kr".to_string());
     }
 
     // lvm2 provides device-mapper, required by mkinitcpio encrypt/lvm2 hooks
@@ -221,7 +220,6 @@ const CUSTOM_PKG_PREFIXES: &[&str] = &[
     "deploytix-gui-git-",
     "tkg-gui-git-",
     "modular-git-",
-    "unl0kr-",
 ];
 
 /// All custom package names that may live in the [deploytix] repo.
@@ -230,7 +228,6 @@ const CUSTOM_PACKAGE_NAMES: &[&str] = &[
     "deploytix-gui-git",
     "tkg-gui-git",
     "modular-git",
-    "unl0kr",
 ];
 
 /// Path where the ISO live-overlay embeds the deploytix repo.
@@ -389,11 +386,10 @@ fn locate_prebuilt_packages() -> Vec<PathBuf> {
         // repo root
         {
             search_dirs.push(repo_root.join("pkg"));
-            // Sibling tkg-gui, Modular-1, and unl0kr repos.
+            // Sibling tkg-gui and Modular-1 repos.
             if let Some(parent) = repo_root.parent() {
                 search_dirs.push(parent.join("tkg-gui/pkg"));
                 search_dirs.push(parent.join("Modular-1/pkg"));
-                search_dirs.push(parent.join("unl0kr/pkg"));
             }
         }
     }
@@ -403,7 +399,6 @@ fn locate_prebuilt_packages() -> Vec<PathBuf> {
         search_dirs.push(home.join(".gitrepos/Deploytix/pkg"));
         search_dirs.push(home.join(".gitrepos/tkg-gui/pkg"));
         search_dirs.push(home.join(".gitrepos/Modular-1/pkg"));
-        search_dirs.push(home.join(".gitrepos/unl0kr/pkg"));
         search_dirs.push(home.join("artools-workspace/tkg-gui-src/pkg"));
     }
 
@@ -455,7 +450,6 @@ fn repo_dir_for_package(pkg_name: &str) -> &'static str {
         "deploytix-git" | "deploytix-gui-git" => "Deploytix",
         "tkg-gui-git" => "tkg-gui",
         "modular-git" => "Modular-1",
-        "unl0kr" => "unl0kr",
         _ => "",
     }
 }
@@ -809,7 +803,7 @@ pub fn prepare_deploytix_repo(
              To fix, try one of:\n\
              - Run from the Deploytix live ISO (has all packages embedded)\n\
              - Build packages first: cd pkg && makepkg -s\n\
-             - Clone sibling repos (tkg-gui, Modular-1, unl0kr) and build \
+             - Clone sibling repos (tkg-gui, Modular-1) and build \
                their PKGBUILDs\n\
              - Run iso/build-deploytix-iso.sh to build everything at once",
             missing_str


### PR DESCRIPTION
Removes the `unl0kr` package and all associated build/installer plumbing from the repo.

## Changes

### `src/install/basestrap.rs`
- Drop `unl0kr` from the encryption-enabled package list (`cryptsetup` remains).
- Remove `unl0kr` / `unl0kr-` from `CUSTOM_PACKAGE_NAMES` and `CUSTOM_PKG_PREFIXES`.
- Remove `unl0kr/pkg` sibling-repo search dirs (both exe-relative and `~/.gitrepos`).
- Remove the `"unl0kr" => "unl0kr"` arm in `repo_dir_for_package`.
- Update the 'sibling repos' hint in the user-facing error message.

### `iso/profile/deploytix/profile.yaml`
- Drop `unl0kr` from `livefs.packages`.

### `iso/build-deploytix-iso.sh`
- Remove `UNL0KR_LOCAL_DIR` / `UNL0KR_PKG_DIR` globals and their path resolution.
- Drop `UNL0KR_PKG_DIR` from the skip-rebuild package-count check and error message.
- Remove it from the local-repo population loop and live-overlay embed loop.
- Drop `unl0kr` from the GUI profile `yq` merge.

## Verification
- `cargo check --all-targets` — clean.
- `bash -n iso/build-deploytix-iso.sh` — clean.
- `grep -rni unl0kr .` — no matches.