### PR TITLE
feat(pkgdeps): pacman/libalpm-backed dependency tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,141 @@ Deploytix will check for missing dependencies at startup and offer to install th
 - Standard / LVM Thin layout: ~75 GiB
 - Minimal layout: ~25 GiB
 
+## Package Dependency Tracking (`deploytix deps …`)
+
+Deploytix ships a built-in dependency tracker for Artix/Arch packages. It is used internally to plan what `basestrap` will pull in, and exposed as a CLI for inspecting any package in any sync database.
+
+### Why pacman/libalpm metadata, not the Artix website
+
+`packages.artixlinux.org` is a useful **human** reference, but it is not a reliable source of truth for automation:
+
+- **HTML changes break scrapers.** Layout updates silently invalidate selectors.
+- **It lags the actual sync DBs.** The page shows what the index render last saw; the file under `/var/lib/pacman/sync/*.db` is what `pacman` will actually use to resolve a transaction. They can disagree by hours.
+- **It cannot tell you about *your* configuration.** The same package name can resolve to different versions, deps, or providers depending on which repos you have enabled, your `Architecture`, and any `IgnorePkg` / `Server` overrides in `pacman.conf`.
+- **It doesn't know your installed state.** Transaction planning (what would actually be installed) requires consulting `pacman -Sy` databases plus the local `installed` DB — neither of which the website exposes.
+
+For these reasons Deploytix uses the same metadata sources `pacman` itself uses:
+
+1. **libalpm-style sync DB reads** via `pacman -Si`, `pacman -Ss`, and `pactree`.
+2. **Transaction resolution** via `pacman -S --print --print-format '%r/%n %v'` — no installs, no downloads, no system mutation.
+3. **The user's own `pacman.conf`** (or any `--config /path` override) so the answers match what the target system, ISO, or chroot will actually see.
+
+The website remains useful for humans browsing packages — and we link to it in error messages — but it is never parsed or scraped.
+
+### Subcommands
+
+```text
+deploytix deps resolve <package>          # full runtime closure
+deploytix deps tree <package>             # human-readable tree
+deploytix deps reverse <package>          # who depends on this?
+deploytix deps graph <package> -o pkg.dot # Graphviz DOT (≡ pactree -s -g)
+deploytix deps plan-install <package>     # what `pacman -S` would do
+deploytix deps metadata <package>         # full normalized metadata
+deploytix deps compare <pkg-a> <pkg-b>    # diff two packages
+```
+
+Common flags (apply to all `deps` subcommands):
+
+| Flag | Description |
+|---|---|
+| `--config <path>` | alternate `pacman.conf` (e.g. an ISO build profile) |
+| `--dbpath <path>` | alternate pacman db (e.g. `/mnt/var/lib/pacman` for a chroot) |
+| `--root <path>` | alternate root for transaction planning |
+| `--include-optional` | include `optdepends` in the closure |
+| `--include-make` | include `makedepends` |
+| `--include-check` | include `checkdepends` |
+| `--json` | machine-readable output |
+| `--dot` | Graphviz output (also accepted by `resolve`/`tree`/`reverse`) |
+| `--offline <fixture.json>` | bypass pacman entirely; use a JSON fixture (CI/sandbox mode) |
+| `deps plan-install --clean-root` | plan as if no packages are installed (chroot-style) |
+
+### Examples
+
+```bash
+# Full runtime closure of the Artix `base` package, default sync DBs:
+deploytix deps resolve base
+
+# Same query, but planning against a soon-to-be chroot:
+deploytix deps plan-install base \
+    --config ./iso/pacman.conf \
+    --dbpath /mnt/var/lib/pacman \
+    --root /mnt \
+    --clean-root
+
+# Build a DOT graph (equivalent to: pactree -s -g pacman > pacman.dot):
+deploytix deps graph pacman --output pacman.dot
+dot -Tpng pacman.dot -o pacman.png
+
+# Reverse dependency lookup (who would break if I removed glibc?):
+deploytix deps reverse glibc --include-optional
+
+# Stable JSON for CI:
+deploytix deps resolve linux-zen --json --include-optional > closure.json
+```
+
+### Example JSON output
+
+```json
+{
+  "roots": ["base"],
+  "nodes": [
+    {
+      "name": "base",
+      "version": "1.0",
+      "repo": "system",
+      "depends": [
+        { "name": "glibc", "constraint": ">=2.39" },
+        { "name": "pacman" }
+      ],
+      "optdepends": [
+        { "name": "man-db", "description": "read manpages" }
+      ],
+      "provides": [],
+      "conflicts": [],
+      "replaces": [],
+      "required_by": [],
+      "optional_for": [],
+      "groups": [],
+      "licenses": []
+    }
+  ],
+  "edges": [
+    {
+      "from": "base",
+      "to": "glibc",
+      "kind": "runtime",
+      "constraint": ">=2.39"
+    }
+  ],
+  "providers": [
+    { "virtual_name": "sh", "chosen": "bash" }
+  ],
+  "databases_used": ["system", "world", "extra"],
+  "warnings": []
+}
+```
+
+The schema is stable and round-trips through `serde_json::from_str::<DepClosure>(…)`. Edges and nodes are sorted deterministically so the output diffs cleanly.
+
+### Architecture
+
+| Module | Responsibility |
+|---|---|
+| `pkgdeps::model` | Normalized `Package`, `Dep`, `EdgeKind`, `DepClosure`, `InstallPlan` types. Version constraints and optdep descriptions preserved. |
+| `pkgdeps::source` | `MetadataSource` trait + in-memory `MockSource` for tests/`--offline`. |
+| `pkgdeps::pacman` | Production backend: shells out to `pacman` / `pactree` / `pacman-conf` / `expac` through the small `CmdExec` trait, with `--config` / `--dbpath` / `--root` plumbing. |
+| `pkgdeps::resolver` | Recursive closure with provider resolution, conflicts, replacements. Reverse-dep walk. Package diff. |
+| `pkgdeps::graph` | Graphviz DOT serializer with edge-kind-coloured edges. |
+| `pkgdeps::cli` | Subcommand handlers, JSON / DOT / human formatters, offline fixture loader. |
+
+Because `MetadataSource` is a trait, all of the resolver and graph logic is testable without pacman installed: the test suite drives an in-memory mock and exercises the same code paths real users hit. On a real Artix system, the `PacmanSource` backend takes over and runs the actual `pacman -Si` / `pactree` / `pacman -S --print` invocations — never modifying system state.
+
+### Known limitations
+
+- `optional_for` reverse lookups use `expac -S '%n %O'`. If `expac` is not installed, optional reverse-deps are reported as empty rather than failing the command. Install `expac` (extra repo) for full coverage.
+- The bundled `MockSource` does not enforce version-constraint satisfiability; pacman itself does that at install time. Use `deps plan-install` to surface real conflicts.
+- Stale local sync DB (`/var/lib/pacman/sync/*.db`) will silently produce stale resolutions. The CLI emits a warning when the closure is empty; refresh with `pacman -Sy` (which Deploytix never does on its own).
+
 ## Development
 
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod configure;
 pub mod desktop;
 pub mod disk;
 pub mod install;
+pub mod pkgdeps;
 pub mod resources;
 pub mod utils;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,113 @@ mod configure;
 mod desktop;
 mod disk;
 mod install;
+mod pkgdeps;
 mod resources;
 mod utils;
 
 use crate::config::DeploymentConfig;
+use crate::pkgdeps::cli as deps_cli;
 use crate::utils::error::DeploytixError;
+
+#[derive(clap::Args, Debug, Clone, Default)]
+struct DepsCommonArgs {
+    /// Path to an alternate pacman.conf
+    #[arg(long)]
+    config: Option<String>,
+    /// Path to an alternate pacman database directory (e.g. /mnt/var/lib/pacman)
+    #[arg(long)]
+    dbpath: Option<String>,
+    /// Path to an alternate root (chroot-style planning)
+    #[arg(long)]
+    root: Option<String>,
+    /// Include optdepends in the closure / output
+    #[arg(long)]
+    include_optional: bool,
+    /// Include makedepends
+    #[arg(long)]
+    include_make: bool,
+    /// Include checkdepends
+    #[arg(long)]
+    include_check: bool,
+    /// Emit JSON output
+    #[arg(long)]
+    json: bool,
+    /// Emit Graphviz DOT output (overridden by --json for json-capable commands)
+    #[arg(long)]
+    dot: bool,
+    /// Use an offline JSON fixture instead of pacman (for CI / sandboxes)
+    #[arg(long)]
+    offline: Option<String>,
+}
+
+impl DepsCommonArgs {
+    fn into_args(self) -> deps_cli::DepsArgs {
+        deps_cli::DepsArgs {
+            config: self.config,
+            dbpath: self.dbpath,
+            root: self.root,
+            include_optional: self.include_optional,
+            include_make: self.include_make,
+            include_check: self.include_check,
+            json: self.json,
+            dot: self.dot,
+            offline: self.offline,
+        }
+    }
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum DepsCommand {
+    /// Resolve the full dependency closure of a package
+    Resolve {
+        package: String,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// Print the dependency tree for a package
+    Tree {
+        package: String,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// List packages that require the target (reverse deps)
+    Reverse {
+        package: String,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// Render the dependency graph as Graphviz DOT
+    Graph {
+        package: String,
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<String>,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// Show what `pacman -S --print` would install for a package
+    PlanInstall {
+        package: String,
+        /// Plan against a clean root (chroot-style; ignores already-installed)
+        #[arg(long)]
+        clean_root: bool,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// Print full normalized metadata for a package
+    Metadata {
+        package: String,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+    /// Diff two packages' metadata
+    Compare {
+        a: String,
+        b: String,
+        #[command(flatten)]
+        common: DepsCommonArgs,
+    },
+}
 
 #[derive(Parser)]
 #[command(name = "deploytix")]
@@ -80,6 +182,12 @@ enum Commands {
         wipe: bool,
     },
 
+    /// Query Artix/Arch package dependency metadata via pacman / libalpm
+    Deps {
+        #[command(subcommand)]
+        action: DepsCommand,
+    },
+
     /// Generate desktop file for the GUI launcher
     GenerateDesktopFile {
         /// Desktop environment (kde, gnome, xfce, none)
@@ -136,6 +244,9 @@ fn main() -> Result<()> {
         }
         Some(Commands::Cleanup { device, wipe }) => {
             cmd_cleanup(device, wipe, dry_run)?;
+        }
+        Some(Commands::Deps { action }) => {
+            cmd_deps(action)?;
         }
         Some(Commands::GenerateDesktopFile { de, bindir, output }) => {
             cmd_generate_desktop_file(de, bindir, output)?;
@@ -273,6 +384,55 @@ fn cmd_generate_desktop_file(
     std::fs::write(&output, content)?;
     println!("✓ Desktop file generated for {} at {}", desktop_env, output);
 
+    Ok(())
+}
+
+fn cmd_deps(action: DepsCommand) -> Result<()> {
+    match action {
+        DepsCommand::Resolve { package, common } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_resolve(source.as_ref(), &package, &args)?;
+        }
+        DepsCommand::Tree { package, common } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_tree(source.as_ref(), &package, &args)?;
+        }
+        DepsCommand::Reverse { package, common } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_reverse(source.as_ref(), &package, &args)?;
+        }
+        DepsCommand::Graph {
+            package,
+            output,
+            common,
+        } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_graph(source.as_ref(), &package, output.as_deref(), &args)?;
+        }
+        DepsCommand::PlanInstall {
+            package,
+            clean_root,
+            common,
+        } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_plan_install(source.as_ref(), &package, clean_root, &args)?;
+        }
+        DepsCommand::Metadata { package, common } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_metadata(source.as_ref(), &package, &args)?;
+        }
+        DepsCommand::Compare { a, b, common } => {
+            let args = common.into_args();
+            let source = deps_cli::build_source(&args)?;
+            deps_cli::cmd_compare(source.as_ref(), &a, &b, &args)?;
+        }
+    }
     Ok(())
 }
 

--- a/src/pkgdeps/cli.rs
+++ b/src/pkgdeps/cli.rs
@@ -1,0 +1,460 @@
+//! `deploytix deps …` subcommand handlers.
+//!
+//! Each handler accepts a [`MetadataSource`] so the CLI is agnostic to
+//! whether resolution comes from real pacman or a fixture.
+
+use super::graph::{to_dot, DotOpts};
+use super::model::{DepClosure, InstallPlan};
+use super::pacman::{PacmanConfig, PacmanSource};
+use super::resolver::{self, ResolveOpts};
+use super::source::{MetadataSource, MockSource};
+use crate::utils::error::{DeploytixError, Result};
+use serde::Serialize;
+use std::path::Path;
+
+/// Resolved CLI arguments after parsing — kept simple to allow this
+/// module to be reused from a future GUI frontend.
+#[derive(Debug, Clone, Default)]
+pub struct DepsArgs {
+    pub config: Option<String>,
+    pub dbpath: Option<String>,
+    pub root: Option<String>,
+    pub include_optional: bool,
+    pub include_make: bool,
+    pub include_check: bool,
+    pub json: bool,
+    pub dot: bool,
+    /// Path to an offline fixture (JSON list of `Package`) to use
+    /// instead of pacman. Useful for CI.
+    pub offline: Option<String>,
+}
+
+impl DepsArgs {
+    pub fn pacman_config(&self) -> PacmanConfig {
+        PacmanConfig {
+            config: self.config.clone(),
+            dbpath: self.dbpath.clone(),
+            root: self.root.clone(),
+        }
+    }
+
+    pub fn resolve_opts(&self) -> ResolveOpts {
+        ResolveOpts {
+            include_optional: self.include_optional,
+            include_make: self.include_make,
+            include_check: self.include_check,
+        }
+    }
+}
+
+/// Construct the metadata source the CLI should use given the args.
+pub fn build_source(args: &DepsArgs) -> Result<Box<dyn MetadataSource>> {
+    if let Some(path) = &args.offline {
+        let mock = load_offline_fixture(Path::new(path))?;
+        Ok(Box::new(mock))
+    } else {
+        Ok(Box::new(PacmanSource::system(args.pacman_config())))
+    }
+}
+
+/// Read a JSON fixture from disk into a [`MockSource`]. Format:
+/// `{ "packages": [Package, …], "installed": ["pkg", …], "databases": [...] }`.
+pub fn load_offline_fixture(path: &Path) -> Result<MockSource> {
+    let text = std::fs::read_to_string(path)?;
+    #[derive(serde::Deserialize)]
+    struct Fixture {
+        #[serde(default)]
+        packages: Vec<super::model::Package>,
+        #[serde(default)]
+        installed: Vec<String>,
+        #[serde(default)]
+        databases: Vec<String>,
+        #[serde(default)]
+        providers: Vec<super::model::ProviderChoice>,
+    }
+    let fixture: Fixture = serde_json::from_str(&text).map_err(|e| {
+        DeploytixError::ConfigError(format!("invalid offline fixture {}: {}", path.display(), e))
+    })?;
+    let mut mock = MockSource::default();
+    for p in fixture.packages {
+        mock.insert(p);
+    }
+    for n in fixture.installed {
+        mock.mark_installed(&n);
+    }
+    if !fixture.databases.is_empty() {
+        mock.set_databases(fixture.databases);
+    }
+    for pc in fixture.providers {
+        mock.set_provider(&pc.virtual_name, &pc.chosen);
+    }
+    Ok(mock)
+}
+
+#[derive(Serialize)]
+struct ResolveOutput<'a> {
+    closure: &'a DepClosure,
+}
+
+pub fn cmd_resolve(source: &dyn MetadataSource, package: &str, args: &DepsArgs) -> Result<()> {
+    let closure = resolver::resolve_closure(source, &[package], args.resolve_opts())?;
+    if args.json {
+        print_json(&ResolveOutput { closure: &closure })?;
+    } else if args.dot {
+        print!("{}", to_dot(&closure, DotOpts::default()));
+    } else {
+        for pkg in &closure.nodes {
+            println!("{} {} ({})", pkg.name, pkg.version, pkg.repo);
+        }
+        if !closure.unresolved.is_empty() {
+            eprintln!("\nunresolved: {}", closure.unresolved.join(", "));
+        }
+        emit_warnings(&closure.warnings);
+    }
+    Ok(())
+}
+
+pub fn cmd_tree(source: &dyn MetadataSource, package: &str, args: &DepsArgs) -> Result<()> {
+    let closure = resolver::resolve_closure(source, &[package], args.resolve_opts())?;
+    if args.json {
+        print_json(&closure)?;
+    } else if args.dot {
+        print!("{}", to_dot(&closure, DotOpts::default()));
+    } else {
+        print_tree(&closure, package, 0, &mut std::collections::BTreeSet::new());
+        emit_warnings(&closure.warnings);
+    }
+    Ok(())
+}
+
+fn print_tree(
+    closure: &DepClosure,
+    name: &str,
+    depth: usize,
+    seen: &mut std::collections::BTreeSet<String>,
+) {
+    let prefix = "  ".repeat(depth);
+    println!("{}{}", prefix, name);
+    if !seen.insert(name.to_string()) {
+        return;
+    }
+    for edge in closure.edges.iter().filter(|e| e.from == name) {
+        print_tree(closure, &edge.to, depth + 1, seen);
+    }
+}
+
+pub fn cmd_reverse(source: &dyn MetadataSource, package: &str, args: &DepsArgs) -> Result<()> {
+    let closure = resolver::resolve_reverse(source, package, true, args.include_optional)?;
+    if args.json {
+        print_json(&closure)?;
+    } else if args.dot {
+        print!("{}", to_dot(&closure, DotOpts::default()));
+    } else {
+        for pkg in &closure.nodes {
+            if pkg.name == package {
+                continue;
+            }
+            println!("{}", pkg.name);
+        }
+        emit_warnings(&closure.warnings);
+    }
+    Ok(())
+}
+
+pub fn cmd_graph(
+    source: &dyn MetadataSource,
+    package: &str,
+    output: Option<&str>,
+    args: &DepsArgs,
+) -> Result<()> {
+    let closure = resolver::resolve_closure(source, &[package], args.resolve_opts())?;
+    let dot = to_dot(&closure, DotOpts::default());
+    match output {
+        Some(path) => {
+            std::fs::write(path, dot)?;
+            println!("✓ Wrote graph to {}", path);
+        }
+        None => print!("{}", dot),
+    }
+    emit_warnings(&closure.warnings);
+    Ok(())
+}
+
+pub fn cmd_plan_install(
+    source: &dyn MetadataSource,
+    package: &str,
+    clean_root: bool,
+    args: &DepsArgs,
+) -> Result<()> {
+    let plan = source.install_plan(&[package], clean_root)?;
+    if args.json {
+        print_json(&plan)?;
+    } else {
+        print_plan_human(&plan);
+    }
+    Ok(())
+}
+
+fn print_plan_human(plan: &InstallPlan) {
+    println!(
+        "Targets: {}  ({}clean root)",
+        plan.targets.join(" "),
+        if plan.clean_root { "" } else { "non-" }
+    );
+    println!("Would install ({}):", plan.to_install.len());
+    for p in &plan.to_install {
+        println!(
+            "  {}/{} {}",
+            if p.repo.is_empty() { "?" } else { &p.repo },
+            p.name,
+            p.version
+        );
+    }
+    if !plan.to_remove.is_empty() {
+        println!("Would remove ({}):", plan.to_remove.len());
+        for p in &plan.to_remove {
+            println!("  {}", p);
+        }
+    }
+    emit_warnings(&plan.warnings);
+}
+
+pub fn cmd_metadata(source: &dyn MetadataSource, package: &str, args: &DepsArgs) -> Result<()> {
+    let pkg = source.package(package)?.ok_or_else(|| {
+        DeploytixError::ConfigError(format!(
+            "package '{}' not found in any sync database",
+            package
+        ))
+    })?;
+    if args.json {
+        print_json(&pkg)?;
+    } else {
+        println!("Name        : {}", pkg.name);
+        println!("Version     : {}", pkg.version);
+        println!("Repository  : {}", pkg.repo);
+        println!("Description : {}", pkg.description);
+        println!("URL         : {}", pkg.url);
+        println!("Licenses    : {}", pkg.licenses.join(" "));
+        println!(
+            "Depends     : {}",
+            pkg.depends
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!(
+            "MakeDepends : {}",
+            pkg.makedepends
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!(
+            "CheckDepends: {}",
+            pkg.checkdepends
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!("Optional Deps:");
+        for d in &pkg.optdepends {
+            println!("  {}", d.to_token());
+        }
+        println!(
+            "Provides    : {}",
+            pkg.provides
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!(
+            "Conflicts   : {}",
+            pkg.conflicts
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!(
+            "Replaces    : {}",
+            pkg.replaces
+                .iter()
+                .map(|d| d.to_token())
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct CompareOutput<'a> {
+    a: &'a super::model::Package,
+    b: &'a super::model::Package,
+    differences: Vec<String>,
+}
+
+pub fn cmd_compare(
+    source: &dyn MetadataSource,
+    a: &str,
+    b: &str,
+    args: &DepsArgs,
+) -> Result<()> {
+    let pa = source.package(a)?.ok_or_else(|| {
+        DeploytixError::ConfigError(format!("package '{}' not found", a))
+    })?;
+    let pb = source.package(b)?.ok_or_else(|| {
+        DeploytixError::ConfigError(format!("package '{}' not found", b))
+    })?;
+    let differences = resolver::diff_packages(&pa, &pb);
+    if args.json {
+        print_json(&CompareOutput {
+            a: &pa,
+            b: &pb,
+            differences,
+        })?;
+    } else if differences.is_empty() {
+        println!("{} and {} have identical metadata", a, b);
+    } else {
+        for line in differences {
+            println!("{}", line);
+        }
+    }
+    Ok(())
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    let text = serde_json::to_string_pretty(value).map_err(|e| {
+        DeploytixError::ConfigError(format!("json serialization failed: {}", e))
+    })?;
+    println!("{}", text);
+    Ok(())
+}
+
+fn emit_warnings(warnings: &[String]) {
+    for w in warnings {
+        eprintln!("warning: {}", w);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkgdeps::model::{Dep, Package};
+
+    fn fixture_source() -> MockSource {
+        let mut s = MockSource::default();
+        let mut foo = Package::new("foo", "1.0", "world");
+        foo.depends = vec![Dep::parse("bar>=1.0"), Dep::parse("sh")];
+        foo.optdepends = vec![Dep::parse("git: optional plugin")];
+        s.insert(foo);
+
+        let bar = Package::new("bar", "1.2", "world");
+        s.insert(bar);
+
+        let mut bash = Package::new("bash", "5.2", "system");
+        bash.provides = vec![Dep::unversioned("sh")];
+        s.insert(bash);
+
+        s.insert(Package::new("git", "2.45", "extra"));
+        s.set_databases(vec!["world".into(), "system".into(), "extra".into()]);
+        s
+    }
+
+    #[test]
+    fn json_output_is_stable() {
+        let src = fixture_source();
+        let closure = resolver::resolve_closure(&src, &["foo"], ResolveOpts::default()).unwrap();
+        let json = serde_json::to_string_pretty(&closure).unwrap();
+        // Property: known root is present, dependency is included.
+        assert!(json.contains("\"name\": \"foo\""));
+        assert!(json.contains("\"name\": \"bar\""));
+        // Provider mapping recorded for `sh -> bash`.
+        assert!(json.contains("\"virtual_name\": \"sh\""));
+        // databases_used preserved.
+        assert!(json.contains("\"databases_used\""));
+    }
+
+    #[test]
+    fn install_plan_skips_installed() {
+        let mut src = fixture_source();
+        src.mark_installed("bar");
+        let plan = src.install_plan(&["foo"], false).unwrap();
+        assert!(plan
+            .to_install
+            .iter()
+            .any(|p| p.name == "foo"));
+        assert!(!plan
+            .to_install
+            .iter()
+            .any(|p| p.name == "bar"));
+    }
+
+    #[test]
+    fn install_plan_clean_root_includes_all() {
+        let mut src = fixture_source();
+        src.mark_installed("bar");
+        let plan = src.install_plan(&["foo"], true).unwrap();
+        assert!(plan.clean_root);
+        assert!(plan.to_install.iter().any(|p| p.name == "bar"));
+    }
+
+    #[test]
+    fn fixture_loader_round_trip() {
+        let dir = tempdir();
+        let path = dir.join("fixture.json");
+        let text = serde_json::json!({
+            "packages": [{
+                "name": "foo",
+                "version": "1.0",
+                "repo": "world",
+                "depends": [{"name": "bar"}],
+            }, {
+                "name": "bar",
+                "version": "1.0",
+                "repo": "world"
+            }],
+            "installed": ["bar"],
+            "databases": ["world"],
+        })
+        .to_string();
+        std::fs::write(&path, text).unwrap();
+        let mock = load_offline_fixture(&path).unwrap();
+        assert_eq!(mock.databases(), vec!["world".to_string()]);
+        let plan = mock.install_plan(&["foo"], false).unwrap();
+        assert!(plan.to_install.iter().any(|p| p.name == "foo"));
+        assert!(!plan.to_install.iter().any(|p| p.name == "bar"));
+    }
+
+    #[test]
+    fn different_configs_yield_different_results() {
+        // Same target, two different mock sources standing in for two
+        // different pacman.conf files. The result must differ.
+        let mut a = MockSource::default();
+        a.insert(Package::new("foo", "1.0", "world"));
+        a.set_databases(vec!["world".into()]);
+
+        let mut b = MockSource::default();
+        let mut foo = Package::new("foo", "2.0", "testing");
+        foo.depends = vec![Dep::parse("newdep")];
+        b.insert(foo);
+        b.insert(Package::new("newdep", "0.1", "testing"));
+        b.set_databases(vec!["testing".into()]);
+
+        let ca = resolver::resolve_closure(&a, &["foo"], ResolveOpts::default()).unwrap();
+        let cb = resolver::resolve_closure(&b, &["foo"], ResolveOpts::default()).unwrap();
+        assert_ne!(ca.nodes.len(), cb.nodes.len());
+        assert_ne!(ca.databases_used, cb.databases_used);
+    }
+
+    fn tempdir() -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("deploytix_pkgdeps_test_{}", std::process::id()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/src/pkgdeps/graph.rs
+++ b/src/pkgdeps/graph.rs
@@ -1,0 +1,144 @@
+//! Graphviz DOT serializer for [`DepClosure`] graphs.
+//!
+//! Output is intended to be byte-stable so it can be diffed in CI:
+//! nodes and edges are emitted in the order they appear in the closure
+//! (which the resolver already sorts), and node identifiers are quoted
+//! to survive package names that contain hyphens or `+`.
+
+use super::model::{DepClosure, EdgeKind};
+use std::fmt::Write;
+
+#[derive(Debug, Clone, Copy)]
+pub struct DotOpts {
+    /// Whether the roots should be emphasized in the output (bold).
+    pub highlight_roots: bool,
+}
+
+impl Default for DotOpts {
+    fn default() -> Self {
+        Self {
+            highlight_roots: true,
+        }
+    }
+}
+
+pub fn to_dot(closure: &DepClosure, opts: DotOpts) -> String {
+    let mut out = String::new();
+    out.push_str("digraph deps {\n");
+    out.push_str("    rankdir=LR;\n");
+    out.push_str("    node [shape=box, style=rounded, fontname=\"monospace\"];\n");
+    out.push_str("    edge [fontname=\"monospace\", fontsize=9];\n");
+
+    for pkg in &closure.nodes {
+        let mut attrs = format!("label=\"{}\\n{}\"", escape(&pkg.name), escape(&pkg.version));
+        if opts.highlight_roots && closure.roots.iter().any(|r| r == &pkg.name) {
+            attrs.push_str(", style=\"rounded,bold\", color=\"navy\"");
+        }
+        let _ = writeln!(out, "    \"{}\" [{}];", escape(&pkg.name), attrs);
+    }
+
+    for unr in &closure.unresolved {
+        let _ = writeln!(
+            out,
+            "    \"{}\" [label=\"{}\\n(unresolved)\", style=\"dashed\", color=\"gray60\"];",
+            escape(unr),
+            escape(unr)
+        );
+    }
+
+    for edge in &closure.edges {
+        let mut attrs = format!(
+            "color=\"{}\", style=\"{}\", label=\"{}\"",
+            edge.kind.dot_color(),
+            edge.kind.dot_style(),
+            edge_label(edge)
+        );
+        if matches!(edge.kind, EdgeKind::ReverseRuntime | EdgeKind::ReverseOptional) {
+            attrs.push_str(", arrowhead=invempty");
+        }
+        let _ = writeln!(
+            out,
+            "    \"{}\" -> \"{}\" [{}];",
+            escape(&edge.from),
+            escape(&edge.to),
+            attrs
+        );
+    }
+
+    out.push_str("}\n");
+    out
+}
+
+fn edge_label(edge: &super::model::DepEdge) -> String {
+    match (&edge.constraint, edge.kind) {
+        (Some(c), EdgeKind::Runtime | EdgeKind::Make | EdgeKind::Check) => {
+            format!("{} {}", edge.kind.label(), escape(c))
+        }
+        _ => edge.kind.label().to_string(),
+    }
+}
+
+fn escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkgdeps::model::{Dep, DepEdge, EdgeKind, Package};
+
+    #[test]
+    fn dot_basic_structure() {
+        let mut closure = DepClosure {
+            roots: vec!["foo".into()],
+            nodes: vec![
+                Package::new("foo", "1.0", "system"),
+                Package::new("bar", "2.0", "system"),
+            ],
+            edges: vec![DepEdge {
+                from: "foo".into(),
+                to: "bar".into(),
+                kind: EdgeKind::Runtime,
+                constraint: Some(">=2.0".into()),
+            }],
+            unresolved: Vec::new(),
+            providers: Vec::new(),
+            databases_used: vec!["system".into()],
+            warnings: Vec::new(),
+        };
+        // Force a single optdep to ensure dashed style is emitted.
+        closure.edges.push(DepEdge {
+            from: "foo".into(),
+            to: "git".into(),
+            kind: EdgeKind::Optional,
+            constraint: None,
+        });
+        let dot = to_dot(&closure, DotOpts::default());
+        assert!(dot.starts_with("digraph deps {"));
+        assert!(dot.contains("\"foo\" [label=\"foo\\n1.0\""));
+        assert!(dot.contains("\"foo\" -> \"bar\""));
+        assert!(dot.contains("style=\"solid\""));
+        assert!(dot.contains("style=\"dashed\""));
+        assert!(dot.contains("depends >=2.0"));
+    }
+
+    #[test]
+    fn dot_quotes_special_chars() {
+        let mut p = Package::new("foo+", "1.0", "system");
+        p.depends = vec![Dep::unversioned("bar-baz")];
+        let closure = DepClosure {
+            roots: vec!["foo+".into()],
+            nodes: vec![p, Package::new("bar-baz", "1.0", "system")],
+            edges: vec![DepEdge {
+                from: "foo+".into(),
+                to: "bar-baz".into(),
+                kind: EdgeKind::Runtime,
+                constraint: None,
+            }],
+            ..Default::default()
+        };
+        let dot = to_dot(&closure, DotOpts::default());
+        assert!(dot.contains("\"foo+\""));
+        assert!(dot.contains("\"bar-baz\""));
+    }
+}

--- a/src/pkgdeps/mod.rs
+++ b/src/pkgdeps/mod.rs
@@ -1,0 +1,27 @@
+//! Package dependency tracking for Artix/Arch packages.
+//!
+//! Resolves runtime, build-time, optional, and reverse dependencies from
+//! the pacman/libalpm sync database — never by scraping the Artix website.
+//! See `docs` and the project README for the rationale.
+//!
+//! Submodules:
+//! * [`model`] — normalized package metadata types (`Package`, `Dep`,
+//!   `EdgeKind`, `DepClosure`, etc.).
+//! * [`source`] — the [`source::MetadataSource`] trait and an in-memory
+//!   [`source::MockSource`] used by tests and `--offline` mode.
+//! * [`pacman`] — production backend that shells out to
+//!   `pacman` / `pactree` / `expac` through a [`crate::utils::command::CommandRunner`].
+//! * [`resolver`] — recursive closure, virtual provider resolution,
+//!   conflicts, and reverse-dep walking.
+//! * [`graph`] — Graphviz DOT output equivalent to `pactree -s -g`.
+//! * [`cli`] — the `deploytix deps …` subcommand handlers.
+
+pub mod cli;
+pub mod graph;
+pub mod model;
+pub mod pacman;
+pub mod resolver;
+pub mod source;
+
+pub use model::{Dep, DepClosure, DepKind, EdgeKind, InstallPlan, Package, PackageRef};
+pub use source::{MetadataSource, MockSource};

--- a/src/pkgdeps/model.rs
+++ b/src/pkgdeps/model.rs
@@ -1,0 +1,367 @@
+//! Normalized package metadata types.
+//!
+//! These types intentionally mirror the fields produced by libalpm /
+//! `pacman -Si` so that a `Package` can be losslessly serialized as JSON
+//! and compared across hosts.
+
+use serde::{Deserialize, Serialize};
+
+/// A versioned dependency expression as it appears in pacman metadata.
+///
+/// `name` is the package or virtual provider; `constraint` is the literal
+/// version constraint suffix (`>=1.2.3`, `=4.5`, etc.) when present, or
+/// `None` for an unversioned dep. `description` only applies to optional
+/// dependencies (`optdepends` ships a free-form trailing description after
+/// `: `).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dep {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub constraint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+}
+
+impl Dep {
+    pub fn unversioned<S: Into<String>>(name: S) -> Self {
+        Self {
+            name: name.into(),
+            constraint: None,
+            description: None,
+        }
+    }
+
+    /// Parse a single pacman dep token like `glibc>=2.39`, `sh`, or
+    /// (for optdepends) `git: needed for AUR helpers`.
+    ///
+    /// Optional descriptions are split on the first `: ` — pacman's own
+    /// format. Version constraint operators recognised: `>=`, `<=`, `=`,
+    /// `>`, `<`.
+    pub fn parse(token: &str) -> Self {
+        let (head, description) = match token.split_once(": ") {
+            Some((h, d)) => (h.trim(), Some(d.trim().to_string())),
+            None => (token.trim(), None),
+        };
+
+        for op in [">=", "<=", "=", ">", "<"] {
+            if let Some(idx) = head.find(op) {
+                let (name, rest) = head.split_at(idx);
+                return Self {
+                    name: name.trim().to_string(),
+                    constraint: Some(rest.trim().to_string()),
+                    description,
+                };
+            }
+        }
+
+        Self {
+            name: head.to_string(),
+            constraint: None,
+            description,
+        }
+    }
+
+    /// Serialize back to the canonical `name<op><constraint>` form pacman
+    /// emits. Description (optdepends only) is preserved on a separate
+    /// `: ` suffix to round-trip cleanly.
+    pub fn to_token(&self) -> String {
+        let base = match &self.constraint {
+            Some(c) => format!("{}{}", self.name, c),
+            None => self.name.clone(),
+        };
+        match &self.description {
+            Some(d) => format!("{}: {}", base, d),
+            None => base,
+        }
+    }
+}
+
+/// Which kind of dependency edge produced this entry. Used to keep
+/// build-time deps separate from runtime, and to colour DOT graphs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DepKind {
+    Runtime,
+    Make,
+    Check,
+    Optional,
+}
+
+/// Edge kinds for dependency graph output. Reverse edges share the
+/// graph but are tagged separately so consumers can filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    Runtime,
+    Make,
+    Check,
+    Optional,
+    ReverseRuntime,
+    ReverseOptional,
+}
+
+impl EdgeKind {
+    pub fn dot_color(self) -> &'static str {
+        match self {
+            EdgeKind::Runtime => "black",
+            EdgeKind::Make => "blue",
+            EdgeKind::Check => "darkgreen",
+            EdgeKind::Optional => "gray50",
+            EdgeKind::ReverseRuntime => "red",
+            EdgeKind::ReverseOptional => "orange",
+        }
+    }
+
+    pub fn dot_style(self) -> &'static str {
+        match self {
+            EdgeKind::Optional | EdgeKind::ReverseOptional => "dashed",
+            _ => "solid",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            EdgeKind::Runtime => "depends",
+            EdgeKind::Make => "makedepends",
+            EdgeKind::Check => "checkdepends",
+            EdgeKind::Optional => "optdepends",
+            EdgeKind::ReverseRuntime => "required_by",
+            EdgeKind::ReverseOptional => "optional_for",
+        }
+    }
+}
+
+/// A `repo/name` reference. `repo` is the sync database name (e.g.
+/// `system`, `world`, `extra`). It may be empty when the source did not
+/// report it (older pactree output).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PackageRef {
+    pub repo: String,
+    pub name: String,
+}
+
+impl PackageRef {
+    pub fn new<R: Into<String>, N: Into<String>>(repo: R, name: N) -> Self {
+        Self {
+            repo: repo.into(),
+            name: name.into(),
+        }
+    }
+
+    /// Parse `repo/name` (or just `name`).
+    pub fn parse(s: &str) -> Self {
+        match s.split_once('/') {
+            Some((r, n)) => Self::new(r.trim(), n.trim()),
+            None => Self::new("", s.trim()),
+        }
+    }
+
+    pub fn qualified(&self) -> String {
+        if self.repo.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}/{}", self.repo, self.name)
+        }
+    }
+}
+
+/// Normalized package metadata. Mirrors `pacman -Si` and libalpm's
+/// `alpm_pkg_t` accessors.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Package {
+    pub name: String,
+    pub version: String,
+    pub repo: String,
+    #[serde(default)]
+    pub arch: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub licenses: Vec<String>,
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(default)]
+    pub depends: Vec<Dep>,
+    #[serde(default)]
+    pub makedepends: Vec<Dep>,
+    #[serde(default)]
+    pub checkdepends: Vec<Dep>,
+    #[serde(default)]
+    pub optdepends: Vec<Dep>,
+    #[serde(default)]
+    pub provides: Vec<Dep>,
+    #[serde(default)]
+    pub conflicts: Vec<Dep>,
+    #[serde(default)]
+    pub replaces: Vec<Dep>,
+    /// Reverse runtime deps (`pactree -r`).
+    #[serde(default)]
+    pub required_by: Vec<String>,
+    /// Reverse optional deps (`pactree -ro` equivalent).
+    #[serde(default)]
+    pub optional_for: Vec<String>,
+}
+
+impl Package {
+    pub fn new<S: Into<String>>(name: S, version: S, repo: S) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            repo: repo.into(),
+            arch: String::new(),
+            description: String::new(),
+            url: String::new(),
+            licenses: Vec::new(),
+            groups: Vec::new(),
+            depends: Vec::new(),
+            makedepends: Vec::new(),
+            checkdepends: Vec::new(),
+            optdepends: Vec::new(),
+            provides: Vec::new(),
+            conflicts: Vec::new(),
+            replaces: Vec::new(),
+            required_by: Vec::new(),
+            optional_for: Vec::new(),
+        }
+    }
+
+    pub fn pref(&self) -> PackageRef {
+        PackageRef::new(self.repo.clone(), self.name.clone())
+    }
+}
+
+/// Result of recursively closing the dependency set of one or more
+/// roots. `nodes` is keyed by package name so callers can join back to
+/// metadata; `edges` preserves which kind of dep produced each link
+/// for graph rendering.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DepClosure {
+    pub roots: Vec<String>,
+    pub nodes: Vec<Package>,
+    pub edges: Vec<DepEdge>,
+    /// Names that were referenced but could not be resolved to a real
+    /// package (typically virtual providers with no installed/repo
+    /// satisfier, or packages not in any configured sync DB).
+    #[serde(default)]
+    pub unresolved: Vec<String>,
+    /// Provider mappings actually used (`virtual -> chosen`). Useful for
+    /// debugging and stable JSON output.
+    #[serde(default)]
+    pub providers: Vec<ProviderChoice>,
+    /// Repository databases consulted while resolving.
+    #[serde(default)]
+    pub databases_used: Vec<String>,
+    /// Non-fatal warnings (stale db, missing repo, etc.).
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DepEdge {
+    pub from: String,
+    pub to: String,
+    pub kind: EdgeKind,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub constraint: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderChoice {
+    pub virtual_name: String,
+    pub chosen: String,
+}
+
+/// What `pacman -S --print` would actually do for a given target. Kept
+/// distinct from `DepClosure` because metadata-says ≠ transaction-will:
+/// already-installed packages are omitted, conflicts trigger removals,
+/// replacements alter the node set.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct InstallPlan {
+    pub targets: Vec<String>,
+    /// Packages the transaction would install (`repo/name version`).
+    pub to_install: Vec<PlannedPackage>,
+    /// Packages that would be removed due to conflicts/replacements.
+    #[serde(default)]
+    pub to_remove: Vec<String>,
+    /// Total download size in bytes if reported by pacman.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub download_size: Option<u64>,
+    /// Total installed size in bytes if reported by pacman.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub installed_size: Option<u64>,
+    #[serde(default)]
+    pub warnings: Vec<String>,
+    /// True if planning was done against a clean root (no existing
+    /// installed-db considered) — i.e. equivalent to a fresh chroot.
+    #[serde(default)]
+    pub clean_root: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlannedPackage {
+    pub repo: String,
+    pub name: String,
+    #[serde(default)]
+    pub version: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_unversioned_dep() {
+        let d = Dep::parse("glibc");
+        assert_eq!(d.name, "glibc");
+        assert!(d.constraint.is_none());
+    }
+
+    #[test]
+    fn parse_versioned_dep() {
+        let d = Dep::parse("glibc>=2.39");
+        assert_eq!(d.name, "glibc");
+        assert_eq!(d.constraint.as_deref(), Some(">=2.39"));
+        assert_eq!(d.to_token(), "glibc>=2.39");
+    }
+
+    #[test]
+    fn parse_optdep_with_description() {
+        let d = Dep::parse("git: needed for AUR helpers");
+        assert_eq!(d.name, "git");
+        assert!(d.constraint.is_none());
+        assert_eq!(d.description.as_deref(), Some("needed for AUR helpers"));
+        assert_eq!(d.to_token(), "git: needed for AUR helpers");
+    }
+
+    #[test]
+    fn parse_optdep_versioned() {
+        let d = Dep::parse("python>=3.10: for the foo plugin");
+        assert_eq!(d.name, "python");
+        assert_eq!(d.constraint.as_deref(), Some(">=3.10"));
+        assert_eq!(d.description.as_deref(), Some("for the foo plugin"));
+    }
+
+    #[test]
+    fn package_ref_parse_qualified() {
+        let p = PackageRef::parse("system/glibc");
+        assert_eq!(p.repo, "system");
+        assert_eq!(p.name, "glibc");
+        assert_eq!(p.qualified(), "system/glibc");
+    }
+
+    #[test]
+    fn package_ref_parse_unqualified() {
+        let p = PackageRef::parse("glibc");
+        assert!(p.repo.is_empty());
+        assert_eq!(p.name, "glibc");
+        assert_eq!(p.qualified(), "glibc");
+    }
+
+    #[test]
+    fn edge_kind_styles() {
+        assert_eq!(EdgeKind::Optional.dot_style(), "dashed");
+        assert_eq!(EdgeKind::Runtime.dot_style(), "solid");
+    }
+}

--- a/src/pkgdeps/pacman.rs
+++ b/src/pkgdeps/pacman.rs
@@ -17,7 +17,7 @@
 use super::model::{Dep, InstallPlan, Package, PlannedPackage};
 use super::source::MetadataSource;
 use crate::utils::error::{DeploytixError, Result};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 use tracing::debug;
 
@@ -90,6 +90,11 @@ pub struct PacmanSource<E: CmdExec> {
     cfg: PacmanConfig,
     /// Cached repository list discovered on first call.
     databases: std::sync::OnceLock<Vec<String>>,
+    /// Cached map of `virtual name → list of providing package names`,
+    /// built once from sync DB metadata. `None` means we tried to build
+    /// the index but the underlying tool wasn't available, so callers
+    /// must fall back; an empty map means it was built and is empty.
+    provides_index: std::sync::OnceLock<Option<BTreeMap<String, Vec<String>>>>,
 }
 
 impl<E: CmdExec> PacmanSource<E> {
@@ -98,6 +103,7 @@ impl<E: CmdExec> PacmanSource<E> {
             exec,
             cfg,
             databases: std::sync::OnceLock::new(),
+            provides_index: std::sync::OnceLock::new(),
         }
     }
 
@@ -119,10 +125,85 @@ impl<E: CmdExec> PacmanSource<E> {
             all.push("--dbpath".into());
             all.push(d.clone());
         }
+        if let Some(r) = &self.cfg.root {
+            all.push("--root".into());
+            all.push(r.clone());
+        }
         for a in args {
             all.push((*a).to_string());
         }
         self.exec.run("pactree", &all)
+    }
+
+    /// Build (or return cached) `virtual_name → [providing pkg]` map by
+    /// reading sync DB Provides fields.
+    ///
+    /// Strategy:
+    /// 1. Try `expac -S '%n\t%S'` — emits one line per sync package
+    ///    with name and tab-separated provides field. This is the
+    ///    canonical alpm-backed enumeration.
+    /// 2. If expac is unavailable, try parsing the output of
+    ///    `pacman -Sl` + `pacman -Si` per repo. We avoid that fallback
+    ///    here for cost reasons; callers handle a `None` index by
+    ///    treating the lookup as inconclusive.
+    fn build_provides_index(&self) -> Option<BTreeMap<String, Vec<String>>> {
+        let mut expac_args: Vec<String> = Vec::new();
+        if let Some(c) = &self.cfg.config {
+            expac_args.push("--config".into());
+            expac_args.push(c.clone());
+        }
+        // -S queries sync DBs; %n = name, %S = provides (space-separated).
+        expac_args.push("-S".into());
+        expac_args.push("%n\t%S".into());
+        let out = match self.exec.run("expac", &expac_args) {
+            Ok(s) => s,
+            Err(_) => return None,
+        };
+        let mut map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for line in out.lines() {
+            let mut parts = line.splitn(2, '\t');
+            let name = match parts.next() {
+                Some(n) if !n.is_empty() => n,
+                _ => continue,
+            };
+            let provides_field = parts.next().unwrap_or("");
+            for tok in provides_field.split_whitespace() {
+                let dep = Dep::parse(tok);
+                if dep.name.is_empty() {
+                    continue;
+                }
+                map.entry(dep.name).or_default().push(name.to_string());
+            }
+        }
+        // Stable order, dedup.
+        for v in map.values_mut() {
+            v.sort();
+            v.dedup();
+        }
+        Some(map)
+    }
+
+    fn provides_index(&self) -> Option<&BTreeMap<String, Vec<String>>> {
+        self.provides_index
+            .get_or_init(|| self.build_provides_index())
+            .as_ref()
+    }
+
+    /// Pick the deterministic winner among multiple providers: prefer an
+    /// installed provider, then fall back to alphabetical order.
+    fn choose_provider(&self, candidates: &[String]) -> Option<String> {
+        if candidates.is_empty() {
+            return None;
+        }
+        let mut sorted = candidates.to_vec();
+        sorted.sort();
+        sorted.dedup();
+        for c in &sorted {
+            if self.is_installed(c).unwrap_or(false) {
+                return Some(c.clone());
+            }
+        }
+        sorted.into_iter().next()
     }
 }
 
@@ -148,26 +229,50 @@ impl<E: CmdExec> MetadataSource for PacmanSource<E> {
     }
 
     fn provider_of(&self, virtual_name: &str) -> Result<Option<String>> {
-        // `pacman -Ssq <name>` returns names of packages whose name OR
-        // provides matches; refine with -Si on each candidate. As a
-        // simpler approach we use `pactree --provides` style: ask pacman
-        // -Si <virtual>; if it succeeds the provider is whatever pacman
-        // itself resolves.
+        // 1. Direct sync-DB hit: a real package whose name matches wins.
+        //    `pacman -Si` consults sync DB Name fields.
         if let Some(p) = self.package(virtual_name)? {
             return Ok(Some(p.name));
         }
-        // Fall back: scan sync repos with `pacman -Ss '^<name>$'`.
-        match self.pacman(&["-Ss", &format!("^{}$", virtual_name)]) {
-            Ok(out) => Ok(parse_pacman_ss_first(&out)),
+
+        // 2. Consult actual Provides metadata via the cached index built
+        //    from `expac -S '%n\t%S'`. This is the libalpm-backed path —
+        //    `pacman -Ss` would only match name/description and miss
+        //    soname-style virtual deps such as `sh` or `libfoo.so=1-64`.
+        if let Some(index) = self.provides_index() {
+            if let Some(candidates) = index.get(virtual_name) {
+                if let Some(chosen) = self.choose_provider(candidates) {
+                    return Ok(Some(chosen));
+                }
+            }
+            // Index built and the virtual name is genuinely unknown.
+            return Ok(None);
+        }
+
+        // 3. expac wasn't available — fall back to `pacman -Sii` parsing.
+        //    `-Sii` prints each sync package's full record including the
+        //    Provides field; we scan it for the virtual name. This is
+        //    slower than the index but avoids the original `pacman -Ss`
+        //    bug where matches came from package descriptions, not
+        //    provides.
+        match self.pacman(&["-Sii"]) {
+            Ok(out) => Ok(scan_si_for_provider(
+                &out,
+                virtual_name,
+                |pkg| self.is_installed(pkg).unwrap_or(false),
+            )),
             Err(DeploytixError::CommandFailed { .. }) => Ok(None),
-            Err(e) => Err(e),
+            Err(_) => Ok(None),
         }
     }
 
     fn required_by(&self, name: &str) -> Result<Vec<String>> {
-        // `pactree -r <name>` lists reverse runtime deps. The first line
-        // is the target itself; skip duplicates.
-        let out = match self.pactree(&["-r", "-u", name]) {
+        // `pactree -s -r -u <name>`: -s consults the sync DB (so we
+        // catch reverse deps for packages not installed locally), -r
+        // walks reverse, -u dedupes. Without `-s`, pactree(8) reads
+        // only the local package DB and silently misses repository
+        // reverse deps for not-yet-installed packages.
+        let out = match self.pactree(&["-s", "-r", "-u", name]) {
             Ok(s) => s,
             Err(_) => return Ok(Vec::new()),
         };
@@ -386,20 +491,73 @@ pub fn parse_pacman_si(text: &str) -> Result<Package> {
     })
 }
 
-fn parse_pacman_ss_first(text: &str) -> Option<String> {
-    for line in text.lines() {
-        // Format: `repo/name version ...`; subsequent description lines
-        // start with whitespace.
-        if line.starts_with(' ') || line.starts_with('\t') {
+/// Scan `pacman -Sii` output for any package whose `Provides` field
+/// lists `virtual_name`. Returns the deterministically-chosen winner
+/// (installed package preferred, then alphabetical).
+fn scan_si_for_provider<F>(text: &str, virtual_name: &str, is_installed: F) -> Option<String>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut current_name: Option<String> = None;
+    let mut current_provides: String = String::new();
+    let mut hits: BTreeSet<String> = BTreeSet::new();
+
+    let flush = |name: &Option<String>, provides: &str, hits: &mut BTreeSet<String>| {
+        if let Some(n) = name {
+            for tok in provides.split_whitespace() {
+                if tok.is_empty() {
+                    continue;
+                }
+                let dep = Dep::parse(tok);
+                if dep.name == virtual_name {
+                    hits.insert(n.clone());
+                    break;
+                }
+            }
+        }
+    };
+
+    let mut current_key: Option<String> = None;
+    for raw in text.lines() {
+        if raw.is_empty() {
+            // Record boundary.
+            flush(&current_name, &current_provides, &mut hits);
+            current_name = None;
+            current_provides.clear();
+            current_key = None;
             continue;
         }
-        if let Some((repo_name, _)) = line.split_once(' ') {
-            if let Some((_, name)) = repo_name.split_once('/') {
-                return Some(name.to_string());
+        if raw.starts_with(' ') || raw.starts_with('\t') {
+            if current_key.as_deref() == Some("Provides") {
+                current_provides.push(' ');
+                current_provides.push_str(raw.trim());
+            }
+            continue;
+        }
+        if let Some((key, value)) = raw.split_once(':') {
+            let key = key.trim().to_string();
+            let value = value.trim().to_string();
+            current_key = Some(key.clone());
+            match key.as_str() {
+                "Name" => current_name = Some(value),
+                "Provides" => current_provides = value,
+                _ => {}
             }
         }
     }
-    None
+    flush(&current_name, &current_provides, &mut hits);
+
+    if hits.is_empty() {
+        return None;
+    }
+    let mut sorted: Vec<String> = hits.into_iter().collect();
+    sorted.sort();
+    for c in &sorted {
+        if is_installed(c) {
+            return Some(c.clone());
+        }
+    }
+    sorted.into_iter().next()
 }
 
 fn parse_pactree_unique(text: &str, target: &str) -> Vec<String> {
@@ -549,5 +707,265 @@ Optional For    : gamma
         assert!(names.contains(&"dep2".to_string()));
         assert!(names.contains(&"dep3".to_string()));
         assert!(!names.contains(&"target".to_string()));
+    }
+
+    /// A `CmdExec` that records every call and can answer multiple
+    /// queries from a fixed table without consuming entries — required
+    /// when a single provider lookup makes several pacman/expac calls.
+    struct RecordingExec {
+        responses: Vec<(String, std::result::Result<String, DeploytixError>)>,
+        calls: RefCell<Vec<String>>,
+    }
+
+    impl RecordingExec {
+        fn new(pairs: Vec<(&str, std::result::Result<&str, DeploytixError>)>) -> Self {
+            let responses = pairs
+                .into_iter()
+                .map(|(k, v)| {
+                    let val: std::result::Result<String, DeploytixError> = match v {
+                        Ok(s) => Ok(s.to_string()),
+                        Err(_) => Err(DeploytixError::CommandFailed {
+                            command: k.to_string(),
+                            stderr: "error: target not found".into(),
+                        }),
+                    };
+                    (k.to_string(), val)
+                })
+                .collect();
+            Self {
+                responses,
+                calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.borrow().clone()
+        }
+    }
+
+    impl CmdExec for RecordingExec {
+        fn run(&self, program: &str, args: &[String]) -> Result<String> {
+            let key = format!("{} {}", program, args.join(" "));
+            self.calls.borrow_mut().push(key.clone());
+            // Prefer exact match, then longest prefix match — keeps
+            // disambiguation deterministic when one stored key is a
+            // prefix of another (e.g. "pacman -Si" vs "pacman -Si sh").
+            let mut best: Option<&(String, std::result::Result<String, DeploytixError>)> = None;
+            for entry in &self.responses {
+                if entry.0 == key {
+                    best = Some(entry);
+                    break;
+                }
+                if key.starts_with(entry.0.as_str())
+                    && best
+                        .as_ref()
+                        .map(|b| entry.0.len() > b.0.len())
+                        .unwrap_or(true)
+                {
+                    best = Some(entry);
+                }
+            }
+            if let Some((_, val)) = best {
+                return match val {
+                    Ok(s) => Ok(s.clone()),
+                    Err(DeploytixError::CommandFailed { command, stderr }) => {
+                        Err(DeploytixError::CommandFailed {
+                            command: command.clone(),
+                            stderr: stderr.clone(),
+                        })
+                    }
+                    Err(_) => Err(DeploytixError::CommandNotFound(program.into())),
+                };
+            }
+            Err(DeploytixError::CommandNotFound(program.into()))
+        }
+    }
+
+    /// Bug fix #1 (provider_of): virtual deps such as `sh` must resolve
+    /// to packages whose `Provides` field lists the virtual name, not
+    /// to packages whose name or description happens to match a regex.
+    #[test]
+    fn provider_of_resolves_via_expac_provides_index() {
+        // `pacman -Si sh` fails (sh isn't a real package). expac then
+        // reports that bash provides sh. The lookup MUST succeed
+        // without falling back to the pacman -Ss name/description
+        // search.
+        let exec = RecordingExec::new(vec![
+            (
+                "pacman -Si sh",
+                Err(DeploytixError::CommandFailed {
+                    command: "pacman -Si sh".into(),
+                    stderr: "error: package 'sh' was not found".into(),
+                }),
+            ),
+            (
+                "expac -S %n\t%S",
+                Ok("bash\tsh=5.2 bash=5.2\nzsh\tzsh=5.9\nglibc\t\n"),
+            ),
+            // is_installed checks (called by choose_provider).
+            (
+                "pacman -Qq bash",
+                Err(DeploytixError::CommandFailed {
+                    command: "pacman -Qq bash".into(),
+                    stderr: "error: package 'bash' was not found".into(),
+                }),
+            ),
+        ]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let chosen = src.provider_of("sh").unwrap();
+        assert_eq!(chosen.as_deref(), Some("bash"));
+
+        // Crucially: we must NOT have invoked `pacman -Ss '^sh$'` —
+        // that's the pacman name/description search that misses true
+        // virtual provides.
+        let calls = src.exec.calls();
+        assert!(
+            !calls.iter().any(|c| c.contains("-Ss")),
+            "provider_of fell back to pacman -Ss name/description search; calls: {:?}",
+            calls
+        );
+    }
+
+    /// Bug fix #1 (provider_of): when multiple packages provide the
+    /// same virtual name, prefer an installed one so the choice is
+    /// deterministic and matches what pacman itself would do.
+    #[test]
+    fn provider_of_prefers_installed_provider() {
+        let exec = RecordingExec::new(vec![
+            (
+                "pacman -Si sh",
+                Err(DeploytixError::CommandFailed {
+                    command: "pacman -Si sh".into(),
+                    stderr: "error: package 'sh' was not found".into(),
+                }),
+            ),
+            ("expac -S %n\t%S", Ok("bash\tsh\ndash\tsh\n")),
+            // dash is installed; bash is not. choose_provider must
+            // pick dash even though bash sorts first alphabetically.
+            (
+                "pacman -Qq bash",
+                Err(DeploytixError::CommandFailed {
+                    command: "pacman -Qq bash".into(),
+                    stderr: "error: package 'bash' was not found".into(),
+                }),
+            ),
+            ("pacman -Qq dash", Ok("dash\n")),
+        ]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let chosen = src.provider_of("sh").unwrap();
+        assert_eq!(chosen.as_deref(), Some("dash"));
+    }
+
+    /// Bug fix #1 (provider_of): the index built from `expac -S` must
+    /// preserve version constraints in `Provides` entries — the dep
+    /// parser strips the `=1.2` so the bare virtual name is what we
+    /// key on.
+    #[test]
+    fn provider_of_strips_version_constraint_from_provides() {
+        let exec = RecordingExec::new(vec![
+            (
+                "pacman -Si libcrypto.so",
+                Err(DeploytixError::CommandFailed {
+                    command: "pacman -Si libcrypto.so".into(),
+                    stderr: "error: package 'libcrypto.so' was not found".into(),
+                }),
+            ),
+            (
+                "expac -S %n\t%S",
+                Ok("openssl\tlibcrypto.so=3-64 libssl.so=3-64\n"),
+            ),
+            ("pacman -Qq openssl", Ok("openssl\n")),
+        ]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let chosen = src.provider_of("libcrypto.so").unwrap();
+        assert_eq!(chosen.as_deref(), Some("openssl"));
+    }
+
+    /// Bug fix #2 (required_by): pactree must be invoked with `-s`
+    /// (sync DB) so that reverse-deps for repository packages that
+    /// aren't currently installed are returned.
+    #[test]
+    fn required_by_passes_sync_flag_to_pactree() {
+        let exec = RecordingExec::new(vec![(
+            "pactree -s -r -u glibc",
+            Ok("glibc\nbase\nfilesystem\n"),
+        )]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let parents = src.required_by("glibc").unwrap();
+        assert!(parents.contains(&"base".to_string()));
+        assert!(parents.contains(&"filesystem".to_string()));
+
+        let calls = src.exec.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.starts_with("pactree ") && c.contains(" -s ")),
+            "required_by must invoke pactree with -s; got calls {:?}",
+            calls
+        );
+        // And it must not use the local-DB form (no -s).
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c.starts_with("pactree -r ") || c.starts_with("pactree -r -u ")),
+            "required_by used local-DB pactree form; calls {:?}",
+            calls
+        );
+    }
+
+    /// Bug fix #2 (required_by): pactree must thread the same
+    /// --config/--dbpath/--root overrides as pacman, ahead of the
+    /// `-s -r -u` flags, so chroot/clean-root targets stay consistent.
+    #[test]
+    fn required_by_threads_config_overrides_to_pactree() {
+        let exec = RecordingExec::new(vec![(
+            "pactree --config /tmp/p.conf --dbpath /mnt/var/lib/pacman --root /mnt -s -r -u glibc",
+            Ok("glibc\nbase\n"),
+        )]);
+        let src = PacmanSource::new(
+            exec,
+            PacmanConfig {
+                config: Some("/tmp/p.conf".into()),
+                dbpath: Some("/mnt/var/lib/pacman".into()),
+                root: Some("/mnt".into()),
+            },
+        );
+        let parents = src.required_by("glibc").unwrap();
+        assert!(parents.contains(&"base".to_string()));
+        let calls = src.exec.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.contains("--config /tmp/p.conf") && c.contains(" -s ")),
+            "config overrides not threaded; calls {:?}",
+            calls
+        );
+    }
+
+    /// scan_si_for_provider: the `-Sii` parser must associate Provides
+    /// fields with the right package, including the multi-line form
+    /// where additional provides appear on indented continuation lines.
+    #[test]
+    fn scan_si_for_provider_handles_multiline_provides() {
+        let blob = "\
+Repository      : core
+Name            : bash
+Version         : 5.2
+Provides        : sh=5.2
+                  bash-rl=5.2
+Depends On      : glibc
+
+Repository      : extra
+Name            : zsh
+Version         : 5.9
+Provides        : None
+Depends On      : glibc
+";
+        let chosen = scan_si_for_provider(blob, "sh", |_| false);
+        assert_eq!(chosen.as_deref(), Some("bash"));
+        let chosen2 = scan_si_for_provider(blob, "bash-rl", |_| false);
+        assert_eq!(chosen2.as_deref(), Some("bash"));
+        // virtual that nobody provides
+        assert!(scan_si_for_provider(blob, "ksh", |_| false).is_none());
     }
 }

--- a/src/pkgdeps/pacman.rs
+++ b/src/pkgdeps/pacman.rs
@@ -1,0 +1,553 @@
+//! Production [`MetadataSource`] backed by pacman / pactree / expac.
+//!
+//! All shell-out goes through the small [`CmdExec`] trait so tests can
+//! drive the parser without pacman being installed. The real runner is
+//! [`SystemExec`], which uses [`std::process::Command`] and respects
+//! optional pacman config / dbpath / root overrides.
+//!
+//! Output parsing notes:
+//! * `pacman -Si <pkg>` is consumed for metadata (multi-line `Field : value`).
+//! * `pactree -s <pkg>` (one name per line) gives the dependency list,
+//!   but `-Si` has the version constraints — so we use both.
+//! * `pacman -Qq <pkg>` (`-Q`, not `-S`) tells us whether the package is
+//!   currently installed.
+//! * `pacman -S --print --print-format '%r/%n %v'` is the transaction
+//!   resolver — equivalent to `pacman -S` minus the actual download.
+
+use super::model::{Dep, InstallPlan, Package, PlannedPackage};
+use super::source::MetadataSource;
+use crate::utils::error::{DeploytixError, Result};
+use std::collections::BTreeMap;
+use std::process::Command;
+use tracing::debug;
+
+/// Indirection so tests can mock pacman/pactree output without invoking
+/// the real binaries.
+pub trait CmdExec: Send + Sync {
+    /// Run a command and return its stdout, or an error containing
+    /// stderr if the command exited non-zero.
+    fn run(&self, program: &str, args: &[String]) -> Result<String>;
+}
+
+/// Default executor — runs the real binary via `std::process::Command`.
+#[derive(Debug, Default)]
+pub struct SystemExec;
+
+impl CmdExec for SystemExec {
+    fn run(&self, program: &str, args: &[String]) -> Result<String> {
+        debug!("pkgdeps exec: {} {}", program, args.join(" "));
+        let output = Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|e| {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    DeploytixError::CommandNotFound(program.to_string())
+                } else {
+                    DeploytixError::Io(e)
+                }
+            })?;
+        if !output.status.success() {
+            return Err(DeploytixError::CommandFailed {
+                command: format!("{} {}", program, args.join(" ")),
+                stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            });
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+}
+
+/// pacman/pactree options that need to be threaded through every
+/// invocation. All fields are optional — when unset, pacman falls back
+/// to the system defaults (`/etc/pacman.conf`, `/var/lib/pacman`, `/`).
+#[derive(Debug, Clone, Default)]
+pub struct PacmanConfig {
+    pub config: Option<String>,
+    pub dbpath: Option<String>,
+    pub root: Option<String>,
+}
+
+impl PacmanConfig {
+    fn extra_args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        if let Some(c) = &self.config {
+            args.push("--config".into());
+            args.push(c.clone());
+        }
+        if let Some(d) = &self.dbpath {
+            args.push("--dbpath".into());
+            args.push(d.clone());
+        }
+        if let Some(r) = &self.root {
+            args.push("--root".into());
+            args.push(r.clone());
+        }
+        args
+    }
+}
+
+pub struct PacmanSource<E: CmdExec> {
+    exec: E,
+    cfg: PacmanConfig,
+    /// Cached repository list discovered on first call.
+    databases: std::sync::OnceLock<Vec<String>>,
+}
+
+impl<E: CmdExec> PacmanSource<E> {
+    pub fn new(exec: E, cfg: PacmanConfig) -> Self {
+        Self {
+            exec,
+            cfg,
+            databases: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn pacman(&self, args: &[&str]) -> Result<String> {
+        let mut all = self.cfg.extra_args();
+        for a in args {
+            all.push((*a).to_string());
+        }
+        self.exec.run("pacman", &all)
+    }
+
+    fn pactree(&self, args: &[&str]) -> Result<String> {
+        let mut all = Vec::new();
+        if let Some(c) = &self.cfg.config {
+            all.push("--config".into());
+            all.push(c.clone());
+        }
+        if let Some(d) = &self.cfg.dbpath {
+            all.push("--dbpath".into());
+            all.push(d.clone());
+        }
+        for a in args {
+            all.push((*a).to_string());
+        }
+        self.exec.run("pactree", &all)
+    }
+}
+
+impl PacmanSource<SystemExec> {
+    pub fn system(cfg: PacmanConfig) -> Self {
+        Self::new(SystemExec, cfg)
+    }
+}
+
+impl<E: CmdExec> MetadataSource for PacmanSource<E> {
+    fn package(&self, name: &str) -> Result<Option<Package>> {
+        // `pacman -Si` searches sync DBs only.
+        let out = match self.pacman(&["-Si", name]) {
+            Ok(s) => s,
+            Err(DeploytixError::CommandFailed { stderr, .. })
+                if stderr.contains("was not found") || stderr.contains("target not found") =>
+            {
+                return Ok(None);
+            }
+            Err(e) => return Err(e),
+        };
+        Ok(Some(parse_pacman_si(&out)?))
+    }
+
+    fn provider_of(&self, virtual_name: &str) -> Result<Option<String>> {
+        // `pacman -Ssq <name>` returns names of packages whose name OR
+        // provides matches; refine with -Si on each candidate. As a
+        // simpler approach we use `pactree --provides` style: ask pacman
+        // -Si <virtual>; if it succeeds the provider is whatever pacman
+        // itself resolves.
+        if let Some(p) = self.package(virtual_name)? {
+            return Ok(Some(p.name));
+        }
+        // Fall back: scan sync repos with `pacman -Ss '^<name>$'`.
+        match self.pacman(&["-Ss", &format!("^{}$", virtual_name)]) {
+            Ok(out) => Ok(parse_pacman_ss_first(&out)),
+            Err(DeploytixError::CommandFailed { .. }) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn required_by(&self, name: &str) -> Result<Vec<String>> {
+        // `pactree -r <name>` lists reverse runtime deps. The first line
+        // is the target itself; skip duplicates.
+        let out = match self.pactree(&["-r", "-u", name]) {
+            Ok(s) => s,
+            Err(_) => return Ok(Vec::new()),
+        };
+        Ok(parse_pactree_unique(&out, name))
+    }
+
+    fn optional_for(&self, name: &str) -> Result<Vec<String>> {
+        // pactree has no first-class reverse-optdep mode, but `expac`
+        // does: `expac -Q '%n %O' | grep <name>`. Try it; if expac is
+        // missing, return empty rather than fail.
+        let out = match self.exec.run(
+            "expac",
+            &[
+                "-S".to_string(),
+                "%n %O".to_string(),
+            ],
+        ) {
+            Ok(s) => s,
+            Err(_) => return Ok(Vec::new()),
+        };
+        let mut hits = Vec::new();
+        for line in out.lines() {
+            let mut parts = line.splitn(2, ' ');
+            let pkg = match parts.next() {
+                Some(p) => p,
+                None => continue,
+            };
+            let optdeps_field = parts.next().unwrap_or("");
+            for tok in optdeps_field.split_whitespace() {
+                let dep = Dep::parse(tok);
+                if dep.name == name {
+                    hits.push(pkg.to_string());
+                    break;
+                }
+            }
+        }
+        hits.sort();
+        hits.dedup();
+        Ok(hits)
+    }
+
+    fn is_installed(&self, name: &str) -> Result<bool> {
+        match self.exec.run("pacman", &["-Qq".to_string(), name.to_string()]) {
+            Ok(_) => Ok(true),
+            Err(DeploytixError::CommandFailed { .. }) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
+    fn databases(&self) -> Vec<String> {
+        self.databases
+            .get_or_init(|| {
+                // `pacman-conf --repo-list` is the canonical way.
+                match self.exec.run(
+                    "pacman-conf",
+                    &self
+                        .cfg
+                        .config
+                        .as_ref()
+                        .map(|c| vec!["--config".to_string(), c.clone(), "--repo-list".to_string()])
+                        .unwrap_or_else(|| vec!["--repo-list".to_string()]),
+                ) {
+                    Ok(s) => s
+                        .lines()
+                        .map(|l| l.trim().to_string())
+                        .filter(|l| !l.is_empty())
+                        .collect(),
+                    Err(_) => Vec::new(),
+                }
+            })
+            .clone()
+    }
+
+    fn install_plan(&self, targets: &[&str], clean_root: bool) -> Result<InstallPlan> {
+        let mut args: Vec<String> = self.cfg.extra_args();
+        args.push("-S".into());
+        args.push("--print".into());
+        args.push("--print-format".into());
+        args.push("%r/%n %v".into());
+        if clean_root {
+            // When planning for a chroot/clean root, skip running
+            // hooks and treat the dbpath/root as authoritative — the
+            // caller is expected to have set --root/--dbpath to the
+            // chroot's pacman state.
+            args.push("--noconfirm".into());
+        }
+        for t in targets {
+            args.push((*t).to_string());
+        }
+        let out = match self.exec.run("pacman", &args) {
+            Ok(s) => s,
+            Err(e) => return Err(e),
+        };
+        let mut plan = InstallPlan {
+            targets: targets.iter().map(|s| s.to_string()).collect(),
+            clean_root,
+            ..Default::default()
+        };
+        for line in out.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+            if let Some((repo_name, version)) = line.split_once(' ') {
+                if let Some((repo, name)) = repo_name.split_once('/') {
+                    plan.to_install.push(PlannedPackage {
+                        repo: repo.to_string(),
+                        name: name.to_string(),
+                        version: version.to_string(),
+                    });
+                }
+            }
+        }
+        Ok(plan)
+    }
+}
+
+/// Parse a `pacman -Si <pkg>` output blob into a [`Package`]. Public for
+/// the unit tests; in normal use this is called via `package()`.
+pub fn parse_pacman_si(text: &str) -> Result<Package> {
+    // We collect both a folded single-line view (for whitespace-separated
+    // fields like Depends On) and a list of trimmed lines (for fields
+    // whose entries are one-per-line, like Optional Deps).
+    let mut folded: BTreeMap<String, String> = BTreeMap::new();
+    let mut lines_per_field: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut current_key: Option<String> = None;
+
+    for raw in text.lines() {
+        if raw.is_empty() {
+            current_key = None;
+            continue;
+        }
+        if raw.starts_with(' ') || raw.starts_with('\t') {
+            if let Some(k) = &current_key {
+                let entry = folded.entry(k.clone()).or_default();
+                entry.push(' ');
+                entry.push_str(raw.trim());
+                lines_per_field
+                    .entry(k.clone())
+                    .or_default()
+                    .push(raw.trim().to_string());
+            }
+            continue;
+        }
+        if let Some((key, value)) = raw.split_once(':') {
+            let key = key.trim().to_string();
+            let value = value.trim().to_string();
+            current_key = Some(key.clone());
+            folded.insert(key.clone(), value.clone());
+            lines_per_field.entry(key).or_default().push(value);
+        }
+    }
+
+    let name = folded
+        .get("Name")
+        .cloned()
+        .ok_or_else(|| DeploytixError::ConfigError("pacman -Si: missing Name".into()))?;
+    let version = folded.get("Version").cloned().unwrap_or_default();
+    let repo = folded.get("Repository").cloned().unwrap_or_default();
+
+    let multi = |k: &str| -> Vec<String> {
+        folded
+            .get(k)
+            .map(|v| {
+                v.split_whitespace()
+                    .filter(|t| *t != "None")
+                    .map(|t| t.to_string())
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let multi_dep = |k: &str| -> Vec<Dep> { multi(k).into_iter().map(|t| Dep::parse(&t)).collect() };
+
+    // For optdepends, prefer line-per-entry. If pacman emitted the field
+    // on a single line (e.g. with two-space separators), fall back to
+    // splitting on "  ".
+    let optdepends: Vec<Dep> = match lines_per_field.get("Optional Deps") {
+        Some(lines) if lines.len() > 1 => lines
+            .iter()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty() && *l != "None")
+            .map(Dep::parse)
+            .collect(),
+        _ => {
+            let raw = folded.get("Optional Deps").cloned().unwrap_or_default();
+            if raw.is_empty() || raw == "None" {
+                Vec::new()
+            } else {
+                raw.split("  ")
+                    .map(|t| t.trim())
+                    .filter(|t| !t.is_empty())
+                    .map(Dep::parse)
+                    .collect()
+            }
+        }
+    };
+
+    Ok(Package {
+        name,
+        version,
+        repo,
+        arch: folded.get("Architecture").cloned().unwrap_or_default(),
+        description: folded.get("Description").cloned().unwrap_or_default(),
+        url: folded.get("URL").cloned().unwrap_or_default(),
+        licenses: multi("Licenses"),
+        groups: multi("Groups"),
+        depends: multi_dep("Depends On"),
+        makedepends: multi_dep("Build Depends"),
+        checkdepends: multi_dep("Check Depends"),
+        optdepends,
+        provides: multi_dep("Provides"),
+        conflicts: multi_dep("Conflicts With"),
+        replaces: multi_dep("Replaces"),
+        required_by: multi("Required By"),
+        optional_for: multi("Optional For"),
+    })
+}
+
+fn parse_pacman_ss_first(text: &str) -> Option<String> {
+    for line in text.lines() {
+        // Format: `repo/name version ...`; subsequent description lines
+        // start with whitespace.
+        if line.starts_with(' ') || line.starts_with('\t') {
+            continue;
+        }
+        if let Some((repo_name, _)) = line.split_once(' ') {
+            if let Some((_, name)) = repo_name.split_once('/') {
+                return Some(name.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn parse_pactree_unique(text: &str, target: &str) -> Vec<String> {
+    let mut out: Vec<String> = text
+        .lines()
+        .map(|l| l.trim_start_matches([' ', '\t', '|', '`', '-']).trim().to_string())
+        .filter(|l| !l.is_empty() && l != target)
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    /// Mock executor that returns canned stdout per (program, joined-args).
+    struct CannedExec {
+        responses: RefCell<HashMap<String, std::result::Result<String, DeploytixError>>>,
+    }
+
+    impl CmdExec for CannedExec {
+        fn run(&self, program: &str, args: &[String]) -> Result<String> {
+            let key = format!("{} {}", program, args.join(" "));
+            let key_prefix_match = self
+                .responses
+                .borrow()
+                .keys()
+                .find(|k| key.starts_with(k.as_str()))
+                .cloned();
+            let lookup = key_prefix_match
+                .or_else(|| {
+                    if self.responses.borrow().contains_key(&key) {
+                        Some(key.clone())
+                    } else {
+                        None
+                    }
+                });
+            if let Some(k) = lookup {
+                let mut map = self.responses.borrow_mut();
+                let v = map
+                    .remove(&k)
+                    .unwrap_or_else(|| Err(DeploytixError::CommandNotFound(program.into())));
+                v
+            } else {
+                Err(DeploytixError::CommandNotFound(program.into()))
+            }
+        }
+    }
+
+    fn canned(pairs: &[(&str, std::result::Result<&str, DeploytixError>)]) -> CannedExec {
+        let mut map = HashMap::new();
+        for (k, v) in pairs {
+            let v: std::result::Result<String, DeploytixError> = match v {
+                Ok(s) => Ok((*s).to_string()),
+                Err(_e) => Err(DeploytixError::CommandFailed {
+                    command: k.to_string(),
+                    stderr: "error: target not found".into(),
+                }),
+            };
+            map.insert(k.to_string(), v);
+        }
+        CannedExec {
+            responses: RefCell::new(map),
+        }
+    }
+
+    #[test]
+    fn parses_pacman_si_blob() {
+        let blob = "\
+Repository      : extra
+Name            : foo
+Version         : 1.2.3-4
+Description     : a test package
+Architecture    : x86_64
+URL             : https://example.com
+Licenses        : GPL3
+Groups          : None
+Provides        : foo-impl=1.2
+Depends On      : glibc>=2.39  bar
+Optional Deps   : git: needed for git remotes  python: optional scripting
+Conflicts With  : oldfoo
+Replaces        : ancientfoo
+Required By     : alpha beta
+Optional For    : gamma
+";
+        let pkg = parse_pacman_si(blob).unwrap();
+        assert_eq!(pkg.name, "foo");
+        assert_eq!(pkg.version, "1.2.3-4");
+        assert_eq!(pkg.repo, "extra");
+        assert_eq!(pkg.depends.len(), 2);
+        assert_eq!(pkg.depends[0].name, "glibc");
+        assert_eq!(pkg.depends[0].constraint.as_deref(), Some(">=2.39"));
+        assert!(pkg
+            .optdepends
+            .iter()
+            .any(|d| d.name == "git" && d.description.is_some()));
+        assert_eq!(pkg.required_by, vec!["alpha", "beta"]);
+        assert_eq!(pkg.provides[0].name, "foo-impl");
+    }
+
+    #[test]
+    fn install_plan_parses_print_format() {
+        let exec = canned(&[(
+            "pacman -S --print --print-format %r/%n %v foo",
+            Ok("system/glibc 2.39-1\nworld/foo 1.2.3-4\n"),
+        )]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let plan = src.install_plan(&["foo"], false).unwrap();
+        assert_eq!(plan.to_install.len(), 2);
+        assert_eq!(plan.to_install[1].repo, "world");
+        assert_eq!(plan.to_install[1].name, "foo");
+        assert_eq!(plan.to_install[1].version, "1.2.3-4");
+    }
+
+    #[test]
+    fn install_plan_threads_config_overrides() {
+        // The canned key includes the `--config` prefix, proving the
+        // config was passed through. Order matches PacmanConfig::extra_args:
+        // config, dbpath, root.
+        let exec = canned(&[(
+            "pacman --config /tmp/p.conf --dbpath /mnt/var/lib/pacman --root /mnt -S --print",
+            Ok("custom/foo 0.1-1\n"),
+        )]);
+        let src = PacmanSource::new(
+            exec,
+            PacmanConfig {
+                config: Some("/tmp/p.conf".into()),
+                root: Some("/mnt".into()),
+                dbpath: Some("/mnt/var/lib/pacman".into()),
+            },
+        );
+        let plan = src.install_plan(&["foo"], true).unwrap();
+        assert_eq!(plan.to_install.len(), 1);
+        assert_eq!(plan.to_install[0].repo, "custom");
+        assert!(plan.clean_root);
+    }
+
+    #[test]
+    fn parse_pactree_strips_indent() {
+        let blob = "target\n├─dep1\n│ └─dep2\n└─dep3\n";
+        let names = parse_pactree_unique(blob, "target");
+        assert!(names.contains(&"dep1".to_string()));
+        assert!(names.contains(&"dep2".to_string()));
+        assert!(names.contains(&"dep3".to_string()));
+        assert!(!names.contains(&"target".to_string()));
+    }
+}

--- a/src/pkgdeps/pacman.rs
+++ b/src/pkgdeps/pacman.rs
@@ -21,6 +21,44 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 use tracing::debug;
 
+/// Explicit list delimiter passed to `expac -l`. We pick ASCII unit
+/// separator (`U+001F`) because:
+///   - it is reserved precisely for "subfield separator" in the spec,
+///   - it cannot legally appear in pacman package names, version
+///     constraints, or human-readable optdep descriptions,
+///   - it survives shell argument passing (we go through
+///     `std::process::Command`, not a shell), and
+///   - it is not the documented two-space default for `%O`/`%S`, so
+///     the parser is unambiguous regardless of expac version drift.
+pub(crate) const EXPAC_LIST_DELIM: &str = "\x1f";
+
+/// Split an expac list-field value emitted with `-l <EXPAC_LIST_DELIM>`
+/// into its constituent records. Falls back to the documented default
+/// two-space delimiter for `%O`/`%S` if no unit-separator characters
+/// are present (older expac that ignores `-l`, or a custom build that
+/// emits with the default delimiter regardless). The two-space split
+/// is per `expac(1)` for list fields and is robust to single spaces
+/// inside descriptions like `git: for AUR helpers`.
+pub(crate) fn split_expac_list(field: &str) -> Vec<&str> {
+    let trimmed = field.trim_matches(|c: char| c == '\n' || c == '\r');
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    if trimmed.contains(EXPAC_LIST_DELIM) {
+        return trimmed
+            .split(EXPAC_LIST_DELIM)
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+    // Default expac list delimiter for %O/%S is two spaces.
+    trimmed
+        .split("  ")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 /// Indirection so tests can mock pacman/pactree output without invoking
 /// the real binaries.
 pub trait CmdExec: Send + Sync {
@@ -139,9 +177,13 @@ impl<E: CmdExec> PacmanSource<E> {
     /// reading sync DB Provides fields.
     ///
     /// Strategy:
-    /// 1. Try `expac -S '%n\t%S'` — emits one line per sync package
-    ///    with name and tab-separated provides field. This is the
-    ///    canonical alpm-backed enumeration.
+    /// 1. Try `expac -S -l <LIST_DELIM> '%n\t%S'` — emits one line per
+    ///    sync package with name and a list of provides separated by
+    ///    `LIST_DELIM` (we use ASCII unit separator `\x1f` so names with
+    ///    `=` constraints stay intact). This is the canonical alpm-backed
+    ///    enumeration. Without `-l`, expac would emit `%S` items joined
+    ///    by the default two-space delimiter — fine for `Provides`
+    ///    today but fragile, so we pin the delimiter explicitly.
     /// 2. If expac is unavailable, try parsing the output of
     ///    `pacman -Sl` + `pacman -Si` per repo. We avoid that fallback
     ///    here for cost reasons; callers handle a `None` index by
@@ -152,8 +194,12 @@ impl<E: CmdExec> PacmanSource<E> {
             expac_args.push("--config".into());
             expac_args.push(c.clone());
         }
-        // -S queries sync DBs; %n = name, %S = provides (space-separated).
+        // -S queries sync DBs; -l pins the list delimiter so each %S
+        // entry is recoverable as a single token even if expac's
+        // default ever changes. %n = name, %S = provides list.
         expac_args.push("-S".into());
+        expac_args.push("-l".into());
+        expac_args.push(EXPAC_LIST_DELIM.into());
         expac_args.push("%n\t%S".into());
         let out = match self.exec.run("expac", &expac_args) {
             Ok(s) => s,
@@ -167,7 +213,7 @@ impl<E: CmdExec> PacmanSource<E> {
                 _ => continue,
             };
             let provides_field = parts.next().unwrap_or("");
-            for tok in provides_field.split_whitespace() {
+            for tok in split_expac_list(provides_field) {
                 let dep = Dep::parse(tok);
                 if dep.name.is_empty() {
                     continue;
@@ -281,28 +327,42 @@ impl<E: CmdExec> MetadataSource for PacmanSource<E> {
 
     fn optional_for(&self, name: &str) -> Result<Vec<String>> {
         // pactree has no first-class reverse-optdep mode, but `expac`
-        // does: `expac -Q '%n %O' | grep <name>`. Try it; if expac is
-        // missing, return empty rather than fail.
-        let out = match self.exec.run(
-            "expac",
-            &[
-                "-S".to_string(),
-                "%n %O".to_string(),
-            ],
-        ) {
+        // does. The challenge is that `%O` is a list field whose entries
+        // are `pkgname[: free-form description with spaces]`, joined by
+        // expac's list delimiter (default two spaces). Splitting on
+        // arbitrary whitespace would shred a description like
+        // `git: for AUR helpers` into four fragments, so:
+        //   - we pin the list delimiter to ASCII unit separator (\x1f)
+        //     via `-l`, so each optdepend entry survives as one token;
+        //   - we use a TAB between %n and %O so the package name is
+        //     trivially separable even if the optdep list is empty.
+        // Threads the same --config override pacman uses.
+        let mut expac_args: Vec<String> = Vec::new();
+        if let Some(c) = &self.cfg.config {
+            expac_args.push("--config".into());
+            expac_args.push(c.clone());
+        }
+        expac_args.push("-S".into());
+        expac_args.push("-l".into());
+        expac_args.push(EXPAC_LIST_DELIM.into());
+        expac_args.push("%n\t%O".into());
+        let out = match self.exec.run("expac", &expac_args) {
             Ok(s) => s,
             Err(_) => return Ok(Vec::new()),
         };
         let mut hits = Vec::new();
         for line in out.lines() {
-            let mut parts = line.splitn(2, ' ');
+            let mut parts = line.splitn(2, '\t');
             let pkg = match parts.next() {
-                Some(p) => p,
-                None => continue,
+                Some(p) if !p.is_empty() => p,
+                _ => continue,
             };
             let optdeps_field = parts.next().unwrap_or("");
-            for tok in optdeps_field.split_whitespace() {
+            for tok in split_expac_list(optdeps_field) {
                 let dep = Dep::parse(tok);
+                // Match against the dep name (with any version
+                // constraint stripped by Dep::parse), NOT against
+                // description fragments.
                 if dep.name == name {
                     hits.push(pkg.to_string());
                     break;
@@ -561,9 +621,20 @@ where
 }
 
 fn parse_pactree_unique(text: &str, target: &str) -> Vec<String> {
+    // pactree(8) prefixes children with ASCII tree art (`|-`, `\` -`,
+    // `-`) and, when stdout is a TTY, with the Unicode box-drawing
+    // glyphs `├`, `─`, `│`, `└`. Strip both forms before extracting
+    // the package name on each line.
+    let strip = |c: char| {
+        c.is_whitespace()
+            || matches!(
+                c,
+                ' ' | '\t' | '|' | '`' | '-' | '├' | '─' | '│' | '└' | '┬' | '┐' | '┘'
+            )
+    };
     let mut out: Vec<String> = text
         .lines()
-        .map(|l| l.trim_start_matches([' ', '\t', '|', '`', '-']).trim().to_string())
+        .map(|l| l.trim_start_matches(strip).trim().to_string())
         .filter(|l| !l.is_empty() && l != target)
         .collect();
     out.sort();
@@ -574,37 +645,34 @@ fn parse_pactree_unique(text: &str, target: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
     /// Mock executor that returns canned stdout per (program, joined-args).
+    /// Uses `Mutex` rather than `RefCell` because [`CmdExec`] requires
+    /// `Sync` (the production source is shared across threads).
     struct CannedExec {
-        responses: RefCell<HashMap<String, std::result::Result<String, DeploytixError>>>,
+        responses: Mutex<HashMap<String, std::result::Result<String, DeploytixError>>>,
     }
 
     impl CmdExec for CannedExec {
         fn run(&self, program: &str, args: &[String]) -> Result<String> {
             let key = format!("{} {}", program, args.join(" "));
-            let key_prefix_match = self
-                .responses
-                .borrow()
+            let mut map = self.responses.lock().unwrap();
+            let key_prefix_match = map
                 .keys()
                 .find(|k| key.starts_with(k.as_str()))
                 .cloned();
-            let lookup = key_prefix_match
-                .or_else(|| {
-                    if self.responses.borrow().contains_key(&key) {
-                        Some(key.clone())
-                    } else {
-                        None
-                    }
-                });
+            let lookup = key_prefix_match.or_else(|| {
+                if map.contains_key(&key) {
+                    Some(key.clone())
+                } else {
+                    None
+                }
+            });
             if let Some(k) = lookup {
-                let mut map = self.responses.borrow_mut();
-                let v = map
-                    .remove(&k)
-                    .unwrap_or_else(|| Err(DeploytixError::CommandNotFound(program.into())));
-                v
+                map.remove(&k)
+                    .unwrap_or_else(|| Err(DeploytixError::CommandNotFound(program.into())))
             } else {
                 Err(DeploytixError::CommandNotFound(program.into()))
             }
@@ -624,7 +692,7 @@ mod tests {
             map.insert(k.to_string(), v);
         }
         CannedExec {
-            responses: RefCell::new(map),
+            responses: Mutex::new(map),
         }
     }
 
@@ -712,9 +780,10 @@ Optional For    : gamma
     /// A `CmdExec` that records every call and can answer multiple
     /// queries from a fixed table without consuming entries — required
     /// when a single provider lookup makes several pacman/expac calls.
+    /// `Mutex` (not `RefCell`) because [`CmdExec`] is `Send + Sync`.
     struct RecordingExec {
         responses: Vec<(String, std::result::Result<String, DeploytixError>)>,
-        calls: RefCell<Vec<String>>,
+        calls: Mutex<Vec<String>>,
     }
 
     impl RecordingExec {
@@ -734,19 +803,19 @@ Optional For    : gamma
                 .collect();
             Self {
                 responses,
-                calls: RefCell::new(Vec::new()),
+                calls: Mutex::new(Vec::new()),
             }
         }
 
         fn calls(&self) -> Vec<String> {
-            self.calls.borrow().clone()
+            self.calls.lock().unwrap().clone()
         }
     }
 
     impl CmdExec for RecordingExec {
         fn run(&self, program: &str, args: &[String]) -> Result<String> {
             let key = format!("{} {}", program, args.join(" "));
-            self.calls.borrow_mut().push(key.clone());
+            self.calls.lock().unwrap().push(key.clone());
             // Prefer exact match, then longest prefix match — keeps
             // disambiguation deterministic when one stored key is a
             // prefix of another (e.g. "pacman -Si" vs "pacman -Si sh").
@@ -799,8 +868,8 @@ Optional For    : gamma
                 }),
             ),
             (
-                "expac -S %n\t%S",
-                Ok("bash\tsh=5.2 bash=5.2\nzsh\tzsh=5.9\nglibc\t\n"),
+                "expac -S -l \x1f %n\t%S",
+                Ok("bash\tsh=5.2\x1fbash=5.2\nzsh\tzsh=5.9\nglibc\t\n"),
             ),
             // is_installed checks (called by choose_provider).
             (
@@ -839,7 +908,7 @@ Optional For    : gamma
                     stderr: "error: package 'sh' was not found".into(),
                 }),
             ),
-            ("expac -S %n\t%S", Ok("bash\tsh\ndash\tsh\n")),
+            ("expac -S -l \x1f %n\t%S", Ok("bash\tsh\ndash\tsh\n")),
             // dash is installed; bash is not. choose_provider must
             // pick dash even though bash sorts first alphabetically.
             (
@@ -871,8 +940,8 @@ Optional For    : gamma
                 }),
             ),
             (
-                "expac -S %n\t%S",
-                Ok("openssl\tlibcrypto.so=3-64 libssl.so=3-64\n"),
+                "expac -S -l \x1f %n\t%S",
+                Ok("openssl\tlibcrypto.so=3-64\x1flibssl.so=3-64\n"),
             ),
             ("pacman -Qq openssl", Ok("openssl\n")),
         ]);
@@ -967,5 +1036,167 @@ Depends On      : glibc
         assert_eq!(chosen2.as_deref(), Some("bash"));
         // virtual that nobody provides
         assert!(scan_si_for_provider(blob, "ksh", |_| false).is_none());
+    }
+
+    /// Bug fix #3 (optional_for): each entry in `%O` is `name[: free
+    /// description]`. Descriptions routinely contain spaces. Splitting on
+    /// arbitrary whitespace shreds `git: for AUR helpers` into four
+    /// fragments and `Dep::parse("for")` produces a bogus name `for`,
+    /// so the literal description word would falsely match a target
+    /// looking for any of `for`, `AUR`, `helpers`. Ensure we recover
+    /// each optdep as a complete record using the explicit list
+    /// delimiter.
+    #[test]
+    fn optional_for_parses_descriptions_with_spaces() {
+        // Two packages list `aur-helper` as an optional dep with a
+        // description that contains spaces. The expected match must
+        // be against the dep NAME (`aur-helper`), not against
+        // description fragments.
+        let exec = RecordingExec::new(vec![(
+            "expac -S -l \x1f %n\t%O",
+            Ok("git\taur-helper: for AUR helpers\x1fpython: optional scripting\n\
+pacman\taur-helper: for sync db operations\n\
+unrelated\tfoo: bar baz\n"),
+        )]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let parents = src.optional_for("aur-helper").unwrap();
+        assert_eq!(parents, vec!["git".to_string(), "pacman".to_string()]);
+    }
+
+    /// Bug fix #3 (optional_for): description-only words must not
+    /// produce false positives. Looking for `helpers` or `for` (which
+    /// appear inside the description text) must NOT match.
+    #[test]
+    fn optional_for_does_not_match_description_words() {
+        let exec = RecordingExec::new(vec![(
+            "expac -S -l \x1f %n\t%O",
+            Ok("git\taur-helper: for AUR helpers\x1fpython: optional scripting\n"),
+        )]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+
+        for word in ["for", "AUR", "helpers", "optional", "scripting"] {
+            let parents = src.optional_for(word).unwrap();
+            assert!(
+                parents.is_empty(),
+                "description word `{}` falsely matched: {:?}",
+                word,
+                parents
+            );
+        }
+    }
+
+    /// Bug fix #3 (optional_for): if expac is an older version that
+    /// ignores `-l` and emits `%O` with the documented default two-space
+    /// list delimiter, we must still parse the records correctly. We
+    /// detect the absence of unit-separator characters and fall back
+    /// to splitting on `"  "`.
+    #[test]
+    fn optional_for_falls_back_to_two_space_delim_when_unit_sep_absent() {
+        let exec = RecordingExec::new(vec![(
+            "expac -S -l \x1f %n\t%O",
+            // Two-space-separated entries — the historical expac
+            // default for `%O`. Each entry has a description with
+            // single spaces inside, which two-space splitting handles
+            // but whitespace splitting would not.
+            Ok("git\taur-helper: for AUR helpers  python: optional scripting\n"),
+        )]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let parents = src.optional_for("aur-helper").unwrap();
+        assert_eq!(parents, vec!["git".to_string()]);
+        let parents2 = src.optional_for("python").unwrap();
+        assert_eq!(parents2, vec!["git".to_string()]);
+    }
+
+    /// Bug fix #3 (optional_for): the expac invocation must use a
+    /// robust delimiter strategy. Assert the constructed command pins
+    /// the list delimiter via `-l`, ahead of the format string.
+    #[test]
+    fn optional_for_invokes_expac_with_explicit_list_delimiter() {
+        // Even with empty output, we should be able to inspect the
+        // call shape.
+        let exec = RecordingExec::new(vec![("expac -S -l \x1f %n\t%O", Ok(""))]);
+        let src = PacmanSource::new(exec, PacmanConfig::default());
+        let parents = src.optional_for("anything").unwrap();
+        assert!(parents.is_empty());
+
+        let calls = src.exec.calls();
+        assert!(
+            calls.iter().any(|c| c.contains(" -l \x1f ") && c.contains("%O")),
+            "optional_for did not pin expac list delimiter; calls: {:?}",
+            calls
+        );
+    }
+
+    /// Bug fix #3 (optional_for): `--config` overrides used by pacman
+    /// must also be threaded into the expac invocation, otherwise a
+    /// chroot-style query reads from the wrong sync DB and silently
+    /// returns wrong results.
+    #[test]
+    fn optional_for_threads_config_override() {
+        let exec = RecordingExec::new(vec![(
+            "expac --config /tmp/p.conf -S -l \x1f %n\t%O",
+            Ok("foo\taur-helper: in chroot\n"),
+        )]);
+        let src = PacmanSource::new(
+            exec,
+            PacmanConfig {
+                config: Some("/tmp/p.conf".into()),
+                ..Default::default()
+            },
+        );
+        let parents = src.optional_for("aur-helper").unwrap();
+        assert_eq!(parents, vec!["foo".to_string()]);
+    }
+
+    /// `split_expac_list` round-trip: when expac emits with the unit
+    /// separator we get clean records; when it falls back to the
+    /// two-space default each record still survives intact even with
+    /// spaces inside its description.
+    #[test]
+    fn split_expac_list_handles_both_delimiters() {
+        // Unit-separator path.
+        let v = split_expac_list("git: for AUR helpers\x1fpython: scripts");
+        assert_eq!(v, vec!["git: for AUR helpers", "python: scripts"]);
+
+        // Two-space fallback path.
+        let v = split_expac_list("git: for AUR helpers  python: optional scripting");
+        assert_eq!(
+            v,
+            vec!["git: for AUR helpers", "python: optional scripting"]
+        );
+
+        // Empty / None.
+        assert!(split_expac_list("").is_empty());
+        assert!(split_expac_list("\n").is_empty());
+
+        // Single entry, no delimiters.
+        let v = split_expac_list("git: for AUR helpers");
+        assert_eq!(v, vec!["git: for AUR helpers"]);
+    }
+
+    /// `parse_pacman_si` already handles single-line `Optional Deps`
+    /// using the documented two-space delimiter — make sure
+    /// descriptions with internal spaces still survive end-to-end and
+    /// the parsed dep has the correct name AND preserved description.
+    #[test]
+    fn pacman_si_optdeps_preserve_description_with_spaces() {
+        let blob = "\
+Repository      : extra
+Name            : foo
+Version         : 1.0-1
+Optional Deps   : git: for AUR helpers  python: optional scripting feature
+";
+        let pkg = parse_pacman_si(blob).unwrap();
+        assert_eq!(pkg.optdepends.len(), 2);
+        assert_eq!(pkg.optdepends[0].name, "git");
+        assert_eq!(
+            pkg.optdepends[0].description.as_deref(),
+            Some("for AUR helpers")
+        );
+        assert_eq!(pkg.optdepends[1].name, "python");
+        assert_eq!(
+            pkg.optdepends[1].description.as_deref(),
+            Some("optional scripting feature")
+        );
     }
 }

--- a/src/pkgdeps/resolver.rs
+++ b/src/pkgdeps/resolver.rs
@@ -90,7 +90,7 @@ pub fn resolve_closure<S: MetadataSource + ?Sized>(
                     constraint: d.constraint.clone(),
                 });
                 if !visited.contains_key(&d.name) {
-                    queue.push_back((d.name.clone(), Vec::new()));
+                    queue.push_back(d.name.clone());
                 }
             }
         }
@@ -103,7 +103,7 @@ pub fn resolve_closure<S: MetadataSource + ?Sized>(
                     constraint: d.constraint.clone(),
                 });
                 if !visited.contains_key(&d.name) {
-                    queue.push_back((d.name.clone(), Vec::new()));
+                    queue.push_back(d.name.clone());
                 }
             }
         }
@@ -116,7 +116,7 @@ pub fn resolve_closure<S: MetadataSource + ?Sized>(
                     constraint: d.constraint.clone(),
                 });
                 if !visited.contains_key(&d.name) {
-                    queue.push_back((d.name.clone(), Vec::new()));
+                    queue.push_back(d.name.clone());
                 }
             }
         }

--- a/src/pkgdeps/resolver.rs
+++ b/src/pkgdeps/resolver.rs
@@ -1,0 +1,429 @@
+//! Recursive dependency closure with virtual-provider, conflict, and
+//! reverse-dep handling.
+//!
+//! The resolver is intentionally pure-Rust on top of [`MetadataSource`]
+//! so it works against either the real `PacmanSource` or `MockSource`.
+
+use super::model::{Dep, DepClosure, DepEdge, EdgeKind, Package, ProviderChoice};
+use super::source::MetadataSource;
+use crate::utils::error::Result;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResolveOpts {
+    pub include_optional: bool,
+    pub include_make: bool,
+    pub include_check: bool,
+}
+
+/// Compute the full dependency closure for one or more roots.
+///
+/// Visits each package once; tracks which `provides` virtual names mapped
+/// to which concrete packages so the result is reproducible. Packages that
+/// cannot be resolved are recorded in `unresolved` rather than aborting —
+/// pacman itself will refuse such a transaction at install time, but
+/// graph generation should still succeed.
+pub fn resolve_closure<S: MetadataSource + ?Sized>(
+    source: &S,
+    roots: &[&str],
+    opts: ResolveOpts,
+) -> Result<DepClosure> {
+    let mut visited: BTreeMap<String, Package> = BTreeMap::new();
+    let mut edges: Vec<DepEdge> = Vec::new();
+    let mut unresolved: BTreeSet<String> = BTreeSet::new();
+    let mut providers: BTreeMap<String, String> = BTreeMap::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    for r in roots {
+        queue.push_back(r.to_string());
+    }
+
+    while let Some(name) = queue.pop_front() {
+        if visited.contains_key(&name) {
+            continue;
+        }
+        let resolved = match source.package(&name)? {
+            Some(p) => p,
+            None => {
+                // Maybe `name` is a virtual provider — try resolving.
+                match source.provider_of(&name)? {
+                    Some(provider) => {
+                        providers.insert(name.clone(), provider.clone());
+                        if provider == name {
+                            unresolved.insert(name.clone());
+                            continue;
+                        }
+                        if visited.contains_key(&provider) {
+                            continue;
+                        }
+                        queue.push_back(provider);
+                        continue;
+                    }
+                    None => {
+                        unresolved.insert(name.clone());
+                        continue;
+                    }
+                }
+            }
+        };
+
+        let pkg_name = resolved.name.clone();
+
+        // Enqueue dependencies.
+        for d in &resolved.depends {
+            edges.push(DepEdge {
+                from: pkg_name.clone(),
+                to: d.name.clone(),
+                kind: EdgeKind::Runtime,
+                constraint: d.constraint.clone(),
+            });
+            if !visited.contains_key(&d.name) {
+                queue.push_back(d.name.clone());
+            }
+        }
+        if opts.include_make {
+            for d in &resolved.makedepends {
+                edges.push(DepEdge {
+                    from: pkg_name.clone(),
+                    to: d.name.clone(),
+                    kind: EdgeKind::Make,
+                    constraint: d.constraint.clone(),
+                });
+                if !visited.contains_key(&d.name) {
+                    queue.push_back((d.name.clone(), Vec::new()));
+                }
+            }
+        }
+        if opts.include_check {
+            for d in &resolved.checkdepends {
+                edges.push(DepEdge {
+                    from: pkg_name.clone(),
+                    to: d.name.clone(),
+                    kind: EdgeKind::Check,
+                    constraint: d.constraint.clone(),
+                });
+                if !visited.contains_key(&d.name) {
+                    queue.push_back((d.name.clone(), Vec::new()));
+                }
+            }
+        }
+        if opts.include_optional {
+            for d in &resolved.optdepends {
+                edges.push(DepEdge {
+                    from: pkg_name.clone(),
+                    to: d.name.clone(),
+                    kind: EdgeKind::Optional,
+                    constraint: d.constraint.clone(),
+                });
+                if !visited.contains_key(&d.name) {
+                    queue.push_back((d.name.clone(), Vec::new()));
+                }
+            }
+        }
+
+        visited.insert(pkg_name, resolved);
+    }
+
+    // Rewrite edge targets that point at virtual names whose provider
+    // we already resolved, so the rendered graph references real
+    // packages — pacman would have done this internally.
+    for edge in edges.iter_mut() {
+        if let Some(real) = providers.get(&edge.to) {
+            edge.to = real.clone();
+        }
+    }
+
+    let mut nodes: Vec<Package> = visited.into_values().collect();
+    nodes.sort_by(|a, b| a.name.cmp(&b.name));
+    edges.sort_by(|a, b| {
+        a.from
+            .cmp(&b.from)
+            .then_with(|| a.to.cmp(&b.to))
+            .then_with(|| a.kind.cmp(&b.kind))
+    });
+    edges.dedup();
+
+    let mut warnings = source.staleness_warnings();
+    if nodes.is_empty() && !roots.is_empty() {
+        warnings.push(format!(
+            "no packages resolved for roots: {} — sync database may be empty or stale",
+            roots.join(", ")
+        ));
+    }
+
+    Ok(DepClosure {
+        roots: roots.iter().map(|s| s.to_string()).collect(),
+        nodes,
+        edges,
+        unresolved: unresolved.into_iter().collect(),
+        providers: providers
+            .into_iter()
+            .map(|(virtual_name, chosen)| ProviderChoice {
+                virtual_name,
+                chosen,
+            })
+            .collect(),
+        databases_used: source.databases(),
+        warnings,
+    })
+}
+
+/// Build the reverse dependency closure ("what would break if we removed
+/// `name`?"). Equivalent to `pactree -r -s <pkg>` when `recursive` is
+/// true. Optional reverse deps (`optional_for`) are included when
+/// `include_optional` is set.
+pub fn resolve_reverse<S: MetadataSource + ?Sized>(
+    source: &S,
+    target: &str,
+    recursive: bool,
+    include_optional: bool,
+) -> Result<DepClosure> {
+    let mut visited: BTreeSet<String> = BTreeSet::new();
+    let mut nodes: BTreeMap<String, Package> = BTreeMap::new();
+    let mut edges: Vec<DepEdge> = Vec::new();
+    let mut queue: VecDeque<String> = VecDeque::new();
+
+    queue.push_back(target.to_string());
+
+    while let Some(name) = queue.pop_front() {
+        if !visited.insert(name.clone()) {
+            continue;
+        }
+        if let Some(p) = source.package(&name)? {
+            nodes.entry(name.clone()).or_insert(p);
+        }
+        let parents = source.required_by(&name)?;
+        for parent in parents {
+            edges.push(DepEdge {
+                from: parent.clone(),
+                to: name.clone(),
+                kind: EdgeKind::ReverseRuntime,
+                constraint: None,
+            });
+            if recursive && !visited.contains(&parent) {
+                queue.push_back(parent.clone());
+            }
+            if let Some(p) = source.package(&parent)? {
+                nodes.entry(parent).or_insert(p);
+            }
+        }
+        if include_optional {
+            let opt_parents = source.optional_for(&name)?;
+            for parent in opt_parents {
+                edges.push(DepEdge {
+                    from: parent.clone(),
+                    to: name.clone(),
+                    kind: EdgeKind::ReverseOptional,
+                    constraint: None,
+                });
+                if recursive && !visited.contains(&parent) {
+                    queue.push_back(parent.clone());
+                }
+                if let Some(p) = source.package(&parent)? {
+                    nodes.entry(parent).or_insert(p);
+                }
+            }
+        }
+    }
+
+    let mut node_vec: Vec<Package> = nodes.into_values().collect();
+    node_vec.sort_by(|a, b| a.name.cmp(&b.name));
+    edges.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
+    edges.dedup();
+
+    let mut warnings = source.staleness_warnings();
+    if node_vec.len() <= 1 && edges.is_empty() {
+        warnings.push(format!(
+            "no packages depend on {} (or sync db not refreshed)",
+            target
+        ));
+    }
+
+    Ok(DepClosure {
+        roots: vec![target.to_string()],
+        nodes: node_vec,
+        edges,
+        unresolved: Vec::new(),
+        providers: Vec::new(),
+        databases_used: source.databases(),
+        warnings,
+    })
+}
+
+/// Compare two package metadata records and report differences. Used by
+/// `deps compare`. Returns a list of human-readable lines, empty when
+/// the two packages are dependency-identical.
+pub fn diff_packages(a: &Package, b: &Package) -> Vec<String> {
+    let mut out = Vec::new();
+    if a.version != b.version {
+        out.push(format!(
+            "version: {} -> {}",
+            a.version, b.version
+        ));
+    }
+    let diff_list = |label: &str, av: &[Dep], bv: &[Dep], out: &mut Vec<String>| {
+        let aset: BTreeSet<String> = av.iter().map(|d| d.to_token()).collect();
+        let bset: BTreeSet<String> = bv.iter().map(|d| d.to_token()).collect();
+        for added in bset.difference(&aset) {
+            out.push(format!("+ {}: {}", label, added));
+        }
+        for removed in aset.difference(&bset) {
+            out.push(format!("- {}: {}", label, removed));
+        }
+    };
+    diff_list("depends", &a.depends, &b.depends, &mut out);
+    diff_list("makedepends", &a.makedepends, &b.makedepends, &mut out);
+    diff_list("checkdepends", &a.checkdepends, &b.checkdepends, &mut out);
+    diff_list("optdepends", &a.optdepends, &b.optdepends, &mut out);
+    diff_list("provides", &a.provides, &b.provides, &mut out);
+    diff_list("conflicts", &a.conflicts, &b.conflicts, &mut out);
+    diff_list("replaces", &a.replaces, &b.replaces, &mut out);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkgdeps::model::Dep;
+    use crate::pkgdeps::source::MockSource;
+
+    fn pkg(name: &str, version: &str, deps: &[&str]) -> Package {
+        let mut p = Package::new(name, version, "system");
+        p.depends = deps.iter().map(|d| Dep::parse(d)).collect();
+        p
+    }
+
+    #[test]
+    fn direct_deps_resolved() {
+        let mut s = MockSource::default();
+        s.insert(pkg("foo", "1.0", &["bar", "baz>=2.0"]));
+        s.insert(pkg("bar", "1.0", &[]));
+        s.insert(pkg("baz", "2.5", &[]));
+        s.set_databases(vec!["system".into()]);
+        let closure = resolve_closure(&s, &["foo"], ResolveOpts::default()).unwrap();
+        let names: Vec<&str> = closure.nodes.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["bar", "baz", "foo"]);
+        let constraints: Vec<&str> = closure
+            .edges
+            .iter()
+            .filter_map(|e| e.constraint.as_deref())
+            .collect();
+        assert!(constraints.contains(&">=2.0"));
+    }
+
+    #[test]
+    fn recursive_closure() {
+        let mut s = MockSource::default();
+        s.insert(pkg("a", "1", &["b"]));
+        s.insert(pkg("b", "1", &["c"]));
+        s.insert(pkg("c", "1", &["d"]));
+        s.insert(pkg("d", "1", &[]));
+        let closure = resolve_closure(&s, &["a"], ResolveOpts::default()).unwrap();
+        let names: Vec<&str> = closure.nodes.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn provider_resolution() {
+        let mut s = MockSource::default();
+        let mut a = pkg("a", "1", &["sh"]);
+        a.depends = vec![Dep::unversioned("sh")];
+        s.insert(a);
+        let mut bash = pkg("bash", "5.2", &[]);
+        bash.provides = vec![Dep::unversioned("sh")];
+        s.insert(bash);
+        let closure = resolve_closure(&s, &["a"], ResolveOpts::default()).unwrap();
+        let names: Vec<&str> = closure.nodes.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"bash"));
+        assert!(closure
+            .providers
+            .iter()
+            .any(|p| p.virtual_name == "sh" && p.chosen == "bash"));
+    }
+
+    #[test]
+    fn unresolved_recorded_not_fatal() {
+        let mut s = MockSource::default();
+        s.insert(pkg("a", "1", &["missing"]));
+        let closure = resolve_closure(&s, &["a"], ResolveOpts::default()).unwrap();
+        assert!(closure.unresolved.contains(&"missing".to_string()));
+    }
+
+    #[test]
+    fn optional_only_when_requested() {
+        let mut s = MockSource::default();
+        let mut a = pkg("a", "1", &[]);
+        a.optdepends = vec![Dep {
+            name: "git".into(),
+            constraint: None,
+            description: Some("for AUR".into()),
+        }];
+        s.insert(a);
+        s.insert(pkg("git", "2.45", &[]));
+
+        let closure = resolve_closure(&s, &["a"], ResolveOpts::default()).unwrap();
+        assert!(!closure
+            .nodes
+            .iter()
+            .any(|p| p.name == "git"));
+
+        let closure_opt = resolve_closure(
+            &s,
+            &["a"],
+            ResolveOpts {
+                include_optional: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(closure_opt.nodes.iter().any(|p| p.name == "git"));
+    }
+
+    #[test]
+    fn make_and_check_deps_separate() {
+        let mut s = MockSource::default();
+        let mut a = pkg("a", "1", &[]);
+        a.makedepends = vec![Dep::unversioned("rustc")];
+        a.checkdepends = vec![Dep::unversioned("python-pytest")];
+        s.insert(a);
+        s.insert(pkg("rustc", "1.80", &[]));
+        s.insert(pkg("python-pytest", "8.0", &[]));
+
+        let runtime = resolve_closure(&s, &["a"], ResolveOpts::default()).unwrap();
+        assert_eq!(runtime.nodes.len(), 1);
+
+        let with_make = resolve_closure(
+            &s,
+            &["a"],
+            ResolveOpts {
+                include_make: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(with_make.nodes.iter().any(|p| p.name == "rustc"));
+        assert!(!with_make.nodes.iter().any(|p| p.name == "python-pytest"));
+    }
+
+    #[test]
+    fn reverse_lookup() {
+        let mut s = MockSource::default();
+        s.insert(pkg("a", "1", &["target"]));
+        s.insert(pkg("b", "1", &["target"]));
+        s.insert(pkg("target", "1", &[]));
+        let rev = resolve_reverse(&s, "target", true, false).unwrap();
+        let names: Vec<&str> = rev.nodes.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"a"));
+        assert!(names.contains(&"b"));
+        assert!(names.contains(&"target"));
+    }
+
+    #[test]
+    fn diff_versions_and_deps() {
+        let a = pkg("foo", "1.0", &["bar"]);
+        let b = pkg("foo", "1.1", &["bar", "baz"]);
+        let diff = diff_packages(&a, &b);
+        assert!(diff.iter().any(|l| l.contains("version")));
+        assert!(diff.iter().any(|l| l == "+ depends: baz"));
+    }
+}

--- a/src/pkgdeps/source.rs
+++ b/src/pkgdeps/source.rs
@@ -1,0 +1,234 @@
+//! Metadata source abstraction.
+//!
+//! Anything that can answer "what does package `X` depend on?" plugs in
+//! here: the production [`super::pacman::PacmanSource`] shells out to
+//! pacman/pactree, while [`MockSource`] is a deterministic in-memory
+//! implementation used by tests and `--offline` mode.
+//!
+//! Keeping this as a trait — and dependency-injecting it into the
+//! resolver — is what lets the test suite run inside sandboxes where
+//! pacman is not available.
+
+use super::model::{InstallPlan, Package};
+use crate::utils::error::Result;
+use std::collections::{BTreeMap, HashMap};
+
+/// Read-only access to a pacman-style package universe.
+pub trait MetadataSource {
+    /// Look up a package by name. `None` means the package is not in any
+    /// configured sync database. Implementations MUST NOT mutate system
+    /// state (no `pacman -Sy`, no installs).
+    fn package(&self, name: &str) -> Result<Option<Package>>;
+
+    /// Resolve a virtual name (a `provides` entry) to a concrete package
+    /// name. Returns `None` when nothing in the universe provides it.
+    /// Implementations should be deterministic — typically by preferring
+    /// an installed provider, then alphabetical order — so JSON output
+    /// stays stable.
+    fn provider_of(&self, virtual_name: &str) -> Result<Option<String>>;
+
+    /// Reverse runtime deps: packages whose `depends` list mentions
+    /// `name`. Equivalent to `pactree -r <name>` at depth 1.
+    fn required_by(&self, name: &str) -> Result<Vec<String>>;
+
+    /// Reverse optional deps: packages whose `optdepends` list mentions
+    /// `name`.
+    fn optional_for(&self, name: &str) -> Result<Vec<String>>;
+
+    /// Whether `name` is currently installed on the host. Used so the
+    /// resolver can omit already-installed packages from the install
+    /// plan unless `clean_root` was requested.
+    fn is_installed(&self, name: &str) -> Result<bool>;
+
+    /// Names of the sync databases that were searched. Surfaced in JSON
+    /// output for auditability.
+    fn databases(&self) -> Vec<String>;
+
+    /// Hint that the local sync DB looks stale (e.g., last refreshed
+    /// more than N days ago, or unavailable). Returned warnings are
+    /// merged into `DepClosure::warnings` / `InstallPlan::warnings`.
+    fn staleness_warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// Ask the underlying tooling what `pacman -S --print` would do for
+    /// the given targets. This is intentionally separate from the
+    /// metadata accessors above because it consults pacman's
+    /// transaction resolver, which knows about installed state,
+    /// conflicts, and replacements.
+    fn install_plan(&self, targets: &[&str], clean_root: bool) -> Result<InstallPlan>;
+}
+
+/// In-memory metadata source for tests and `--offline` mode.
+///
+/// Build with [`MockSource::builder`] or directly populate `packages`
+/// and `installed`.
+#[derive(Debug, Default, Clone)]
+pub struct MockSource {
+    packages: BTreeMap<String, Package>,
+    installed: std::collections::BTreeSet<String>,
+    databases: Vec<String>,
+    /// Optional override for `provider_of` — useful when more than one
+    /// package provides the same virtual name and the test wants to
+    /// pin which one wins.
+    provider_overrides: HashMap<String, String>,
+}
+
+impl MockSource {
+    pub fn builder() -> MockSourceBuilder {
+        MockSourceBuilder::default()
+    }
+
+    pub fn insert(&mut self, pkg: Package) {
+        self.packages.insert(pkg.name.clone(), pkg);
+    }
+
+    pub fn mark_installed(&mut self, name: &str) {
+        self.installed.insert(name.to_string());
+    }
+
+    pub fn set_databases(&mut self, dbs: Vec<String>) {
+        self.databases = dbs;
+    }
+
+    pub fn set_provider(&mut self, virtual_name: &str, chosen: &str) {
+        self.provider_overrides
+            .insert(virtual_name.to_string(), chosen.to_string());
+    }
+}
+
+#[derive(Default)]
+pub struct MockSourceBuilder {
+    inner: MockSource,
+}
+
+impl MockSourceBuilder {
+    pub fn package(mut self, pkg: Package) -> Self {
+        self.inner.insert(pkg);
+        self
+    }
+
+    pub fn installed(mut self, name: &str) -> Self {
+        self.inner.mark_installed(name);
+        self
+    }
+
+    pub fn database<S: Into<String>>(mut self, db: S) -> Self {
+        self.inner.databases.push(db.into());
+        self
+    }
+
+    pub fn provider(mut self, virtual_name: &str, chosen: &str) -> Self {
+        self.inner.set_provider(virtual_name, chosen);
+        self
+    }
+
+    pub fn build(self) -> MockSource {
+        self.inner
+    }
+}
+
+impl MetadataSource for MockSource {
+    fn package(&self, name: &str) -> Result<Option<Package>> {
+        Ok(self.packages.get(name).cloned())
+    }
+
+    fn provider_of(&self, virtual_name: &str) -> Result<Option<String>> {
+        if let Some(forced) = self.provider_overrides.get(virtual_name) {
+            return Ok(Some(forced.clone()));
+        }
+        // Direct package match wins (e.g. `sh` → `bash` would normally
+        // need an override, but `glibc` → `glibc` should resolve).
+        if self.packages.contains_key(virtual_name) {
+            return Ok(Some(virtual_name.to_string()));
+        }
+        // Otherwise scan provides; prefer installed, then alphabetical.
+        let mut candidates: Vec<&Package> = self
+            .packages
+            .values()
+            .filter(|p| p.provides.iter().any(|d| d.name == virtual_name))
+            .collect();
+        candidates.sort_by(|a, b| {
+            let a_inst = self.installed.contains(&a.name);
+            let b_inst = self.installed.contains(&b.name);
+            b_inst.cmp(&a_inst).then_with(|| a.name.cmp(&b.name))
+        });
+        Ok(candidates.first().map(|p| p.name.clone()))
+    }
+
+    fn required_by(&self, name: &str) -> Result<Vec<String>> {
+        let mut out: Vec<String> = self
+            .packages
+            .values()
+            .filter(|p| p.depends.iter().any(|d| d.name == name))
+            .map(|p| p.name.clone())
+            .collect();
+        out.sort();
+        Ok(out)
+    }
+
+    fn optional_for(&self, name: &str) -> Result<Vec<String>> {
+        let mut out: Vec<String> = self
+            .packages
+            .values()
+            .filter(|p| p.optdepends.iter().any(|d| d.name == name))
+            .map(|p| p.name.clone())
+            .collect();
+        out.sort();
+        Ok(out)
+    }
+
+    fn is_installed(&self, name: &str) -> Result<bool> {
+        Ok(self.installed.contains(name))
+    }
+
+    fn databases(&self) -> Vec<String> {
+        self.databases.clone()
+    }
+
+    fn install_plan(&self, targets: &[&str], clean_root: bool) -> Result<InstallPlan> {
+        // Synthesize a transaction plan from metadata: walk runtime
+        // deps, skip installed packages unless clean_root is set,
+        // collect conflicts/replacements as removals.
+        use super::resolver;
+        let opts = resolver::ResolveOpts {
+            include_optional: false,
+            include_make: false,
+            include_check: false,
+        };
+        let closure = resolver::resolve_closure(self, targets, opts)?;
+
+        let mut to_install = Vec::new();
+        let mut to_remove = std::collections::BTreeSet::new();
+        for pkg in &closure.nodes {
+            if !clean_root && self.installed.contains(&pkg.name) {
+                continue;
+            }
+            to_install.push(super::model::PlannedPackage {
+                repo: pkg.repo.clone(),
+                name: pkg.name.clone(),
+                version: pkg.version.clone(),
+            });
+            for c in &pkg.conflicts {
+                if self.installed.contains(&c.name) {
+                    to_remove.insert(c.name.clone());
+                }
+            }
+            for r in &pkg.replaces {
+                if self.installed.contains(&r.name) {
+                    to_remove.insert(r.name.clone());
+                }
+            }
+        }
+
+        Ok(InstallPlan {
+            targets: targets.iter().map(|s| s.to_string()).collect(),
+            to_install,
+            to_remove: to_remove.into_iter().collect(),
+            download_size: None,
+            installed_size: None,
+            warnings: closure.warnings,
+            clean_root,
+        })
+    }
+}

--- a/tests/pkgdeps_integration.rs
+++ b/tests/pkgdeps_integration.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the `pkgdeps` module: drive the public API end-to-end
+//! with a `MockSource` standing in for pacman.
+
+use deploytix::pkgdeps::cli as deps_cli;
+use deploytix::pkgdeps::graph::{to_dot, DotOpts};
+use deploytix::pkgdeps::model::{Dep, EdgeKind, Package};
+use deploytix::pkgdeps::resolver::{resolve_closure, resolve_reverse, ResolveOpts};
+use deploytix::pkgdeps::source::{MetadataSource, MockSource};
+use std::path::PathBuf;
+
+fn artix_universe() -> MockSource {
+    let mut s = MockSource::default();
+    s.set_databases(vec!["system".into(), "world".into(), "extra".into()]);
+
+    // base depends on glibc and pacman; pacman depends on libalpm.
+    let mut base = Package::new("base", "1.0", "system");
+    base.depends = vec![Dep::parse("glibc>=2.39"), Dep::parse("pacman")];
+    base.optdepends = vec![Dep::parse("man-db: read manpages")];
+    s.insert(base);
+
+    let glibc = Package::new("glibc", "2.39-1", "system");
+    s.insert(glibc);
+
+    let mut pacman = Package::new("pacman", "6.1.0-1", "system");
+    pacman.depends = vec![Dep::parse("libalpm")];
+    pacman.makedepends = vec![Dep::parse("meson")];
+    pacman.checkdepends = vec![Dep::parse("python-pytest")];
+    pacman.conflicts = vec![Dep::parse("pacman-mirrorlist")];
+    pacman.replaces = vec![Dep::parse("pacman-contrib<1.0")];
+    s.insert(pacman);
+
+    let libalpm = Package::new("libalpm", "13.0", "system");
+    s.insert(libalpm);
+
+    let meson = Package::new("meson", "1.4", "extra");
+    s.insert(meson);
+
+    let pytest = Package::new("python-pytest", "8.0", "extra");
+    s.insert(pytest);
+
+    let mandb = Package::new("man-db", "2.12", "world");
+    s.insert(mandb);
+
+    // virtual provider: `sh` is provided by bash.
+    let mut bash = Package::new("bash", "5.2", "system");
+    bash.provides = vec![Dep::unversioned("sh")];
+    s.insert(bash);
+
+    // user-pkg depends on `sh` (virtual) and base.
+    let mut user_pkg = Package::new("user-pkg", "0.1", "world");
+    user_pkg.depends = vec![Dep::unversioned("sh"), Dep::unversioned("base")];
+    user_pkg.optdepends = vec![Dep::parse("git: for AUR helpers")];
+    s.insert(user_pkg);
+
+    s
+}
+
+#[test]
+fn full_runtime_closure_includes_transitive_deps() {
+    let src = artix_universe();
+    let closure = resolve_closure(&src, &["user-pkg"], ResolveOpts::default()).unwrap();
+    let names: Vec<&str> = closure.nodes.iter().map(|p| p.name.as_str()).collect();
+    for required in ["user-pkg", "base", "glibc", "pacman", "libalpm", "bash"] {
+        assert!(names.contains(&required), "missing: {}", required);
+    }
+    // optdeps of base / user-pkg must NOT appear in default closure.
+    assert!(!names.contains(&"man-db"));
+    assert!(!names.contains(&"git"));
+    // Provider mapping captured.
+    assert!(closure
+        .providers
+        .iter()
+        .any(|p| p.virtual_name == "sh" && p.chosen == "bash"));
+    // Version constraint preserved on edges.
+    assert!(closure
+        .edges
+        .iter()
+        .any(|e| e.to == "glibc" && e.constraint.as_deref() == Some(">=2.39")));
+    // databases_used reported.
+    assert!(closure
+        .databases_used
+        .iter()
+        .any(|d| d == "system"));
+}
+
+#[test]
+fn make_and_check_deps_kept_separate() {
+    let src = artix_universe();
+
+    let runtime = resolve_closure(&src, &["pacman"], ResolveOpts::default()).unwrap();
+    assert!(!runtime.nodes.iter().any(|p| p.name == "meson"));
+    assert!(!runtime.nodes.iter().any(|p| p.name == "python-pytest"));
+
+    let with_make = resolve_closure(
+        &src,
+        &["pacman"],
+        ResolveOpts {
+            include_make: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(with_make.nodes.iter().any(|p| p.name == "meson"));
+    assert!(!with_make.nodes.iter().any(|p| p.name == "python-pytest"));
+
+    let with_check = resolve_closure(
+        &src,
+        &["pacman"],
+        ResolveOpts {
+            include_check: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(with_check.nodes.iter().any(|p| p.name == "python-pytest"));
+
+    // Edges are tagged with the right kind.
+    let make_edge = with_make
+        .edges
+        .iter()
+        .find(|e| e.to == "meson")
+        .expect("meson edge");
+    assert!(matches!(make_edge.kind, EdgeKind::Make));
+}
+
+#[test]
+fn reverse_dependency_walk() {
+    let src = artix_universe();
+    let rev = resolve_reverse(&src, "glibc", true, false).unwrap();
+    let names: Vec<&str> = rev.nodes.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"base"));
+    assert!(names.contains(&"glibc"));
+    // user-pkg is a reverse-runtime of base, so transitively of glibc.
+    assert!(names.contains(&"user-pkg"));
+}
+
+#[test]
+fn install_plan_skips_already_installed() {
+    let mut src = artix_universe();
+    src.mark_installed("glibc");
+    src.mark_installed("libalpm");
+    let plan = src.install_plan(&["pacman"], false).unwrap();
+    let install_names: Vec<&str> = plan.to_install.iter().map(|p| p.name.as_str()).collect();
+    assert!(install_names.contains(&"pacman"));
+    assert!(!install_names.contains(&"glibc"));
+    assert!(!install_names.contains(&"libalpm"));
+    assert!(!plan.clean_root);
+}
+
+#[test]
+fn install_plan_clean_root_treats_all_as_missing() {
+    let mut src = artix_universe();
+    src.mark_installed("glibc");
+    let plan = src.install_plan(&["pacman"], true).unwrap();
+    let install_names: Vec<&str> = plan.to_install.iter().map(|p| p.name.as_str()).collect();
+    assert!(install_names.contains(&"glibc"));
+    assert!(plan.clean_root);
+}
+
+#[test]
+fn dot_output_contains_expected_edges() {
+    let src = artix_universe();
+    let closure = resolve_closure(
+        &src,
+        &["base"],
+        ResolveOpts {
+            include_optional: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let dot = to_dot(&closure, DotOpts::default());
+    assert!(dot.contains("digraph deps"));
+    assert!(dot.contains("\"base\" -> \"glibc\""));
+    assert!(dot.contains("\"base\" -> \"pacman\""));
+    assert!(dot.contains("\"base\" -> \"man-db\""));
+    // optdep edge is dashed.
+    let mandb_line = dot
+        .lines()
+        .find(|l| l.contains("\"base\" -> \"man-db\""))
+        .unwrap();
+    assert!(mandb_line.contains("dashed"));
+    // version constraint shows in edge label
+    assert!(dot.contains("depends >=2.39"));
+}
+
+#[test]
+fn json_output_schema_round_trips() {
+    let src = artix_universe();
+    let closure = resolve_closure(
+        &src,
+        &["user-pkg"],
+        ResolveOpts {
+            include_optional: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let json = serde_json::to_string(&closure).unwrap();
+    let round: deploytix::pkgdeps::DepClosure = serde_json::from_str(&json).unwrap();
+    assert_eq!(round.roots, closure.roots);
+    assert_eq!(round.nodes.len(), closure.nodes.len());
+    assert_eq!(round.edges.len(), closure.edges.len());
+    // Stable, sorted ordering.
+    let mut sorted_names = closure
+        .nodes
+        .iter()
+        .map(|p| p.name.clone())
+        .collect::<Vec<_>>();
+    sorted_names.sort();
+    assert_eq!(
+        closure
+            .nodes
+            .iter()
+            .map(|p| p.name.clone())
+            .collect::<Vec<_>>(),
+        sorted_names
+    );
+}
+
+#[test]
+fn different_configs_produce_different_results() {
+    // Universe A: minimal `world` repo only.
+    let mut a = MockSource::default();
+    a.set_databases(vec!["world".into()]);
+    a.insert(Package::new("foo", "1.0", "world"));
+
+    // Universe B: same package but with deps in `testing` repo.
+    let mut b = MockSource::default();
+    b.set_databases(vec!["testing".into()]);
+    let mut foo = Package::new("foo", "2.0", "testing");
+    foo.depends = vec![Dep::unversioned("newdep")];
+    b.insert(foo);
+    b.insert(Package::new("newdep", "0.1", "testing"));
+
+    let ca = resolve_closure(&a, &["foo"], ResolveOpts::default()).unwrap();
+    let cb = resolve_closure(&b, &["foo"], ResolveOpts::default()).unwrap();
+    assert_ne!(ca.nodes.len(), cb.nodes.len());
+    assert_ne!(ca.databases_used, cb.databases_used);
+    let foo_a = ca.nodes.iter().find(|p| p.name == "foo").unwrap();
+    let foo_b = cb.nodes.iter().find(|p| p.name == "foo").unwrap();
+    assert_ne!(foo_a.version, foo_b.version);
+    assert_ne!(foo_a.repo, foo_b.repo);
+}
+
+#[test]
+fn offline_fixture_round_trip() {
+    let dir = std::env::temp_dir().join(format!(
+        "deploytix_pkgdeps_offline_{}_{}",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path: PathBuf = dir.join("fix.json");
+    let json = serde_json::json!({
+        "packages": [
+            {
+                "name": "alpha",
+                "version": "1.0",
+                "repo": "world",
+                "depends": [{"name": "beta", "constraint": ">=0.5"}],
+                "optdepends": [{"name": "gamma", "description": "extra"}]
+            },
+            {"name": "beta", "version": "0.7", "repo": "world"}
+        ],
+        "installed": [],
+        "databases": ["world"]
+    })
+    .to_string();
+    std::fs::write(&path, json).unwrap();
+
+    let mock = deps_cli::load_offline_fixture(&path).unwrap();
+    let closure = resolve_closure(
+        &mock,
+        &["alpha"],
+        ResolveOpts {
+            include_optional: false,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(closure.nodes.len(), 2);
+    assert_eq!(mock.databases(), vec!["world"]);
+    let alpha = closure.nodes.iter().find(|p| p.name == "alpha").unwrap();
+    assert_eq!(alpha.depends[0].constraint.as_deref(), Some(">=0.5"));
+}

--- a/tests/pkgdeps_integration.rs
+++ b/tests/pkgdeps_integration.rs
@@ -243,6 +243,44 @@ fn different_configs_produce_different_results() {
     assert_ne!(foo_a.repo, foo_b.repo);
 }
 
+/// Regression test for the bug where a virtual dep (e.g. `sh`) would
+/// be marked unresolved when the underlying source could not match it
+/// by name/description. The MockSource models a Provides-aware lookup;
+/// the real `PacmanSource` was changed to consult sync DB Provides
+/// metadata via expac rather than `pacman -Ss`. In both cases, the
+/// closure must include the real provider node and an entry in
+/// `providers`, with no `unresolved` for the virtual name.
+#[test]
+fn virtual_dep_resolves_to_provider_node_not_unresolved() {
+    let src = artix_universe();
+    let closure = resolve_closure(&src, &["user-pkg"], ResolveOpts::default()).unwrap();
+    // `sh` is a virtual provided by bash; it must NOT appear as
+    // unresolved.
+    assert!(
+        !closure.unresolved.iter().any(|u| u == "sh"),
+        "virtual dep `sh` was recorded as unresolved; closure: {:?}",
+        closure
+    );
+    // The real provider (bash) must be present as a node.
+    assert!(closure.nodes.iter().any(|p| p.name == "bash"));
+    // Provider mapping must record the choice.
+    assert!(closure
+        .providers
+        .iter()
+        .any(|p| p.virtual_name == "sh" && p.chosen == "bash"));
+    // Edges originally pointing at `sh` must have been rewritten to
+    // point at the real provider, so graph output references real
+    // packages.
+    assert!(closure
+        .edges
+        .iter()
+        .any(|e| e.from == "user-pkg" && e.to == "bash"));
+    assert!(!closure
+        .edges
+        .iter()
+        .any(|e| e.from == "user-pkg" && e.to == "sh"));
+}
+
 #[test]
 fn offline_fixture_round_trip() {
     let dir = std::env::temp_dir().join(format!(


### PR DESCRIPTION
## Summary
- Add a `pkgdeps` module that resolves runtime, build, optional, and reverse dependencies for Artix/Arch packages directly from pacman sync DBs (via `pacman -Si`, `pactree`, `pacman -S --print`) — explicitly **not** by scraping `packages.artixlinux.org`.
- Expose the resolver as a `deploytix deps …` CLI with subcommands `resolve`, `tree`, `reverse`, `graph`, `plan-install`, `metadata`, `compare`, plus `--config`/`--dbpath`/`--root` overrides for chroot-style planning.
- All tooling sits behind a `MetadataSource` trait + `CmdExec` indirection, so the test suite runs in sandboxes without pacman installed (a JSON-fixture `--offline` mode is also exposed for CI).

## What's in the diff
- `src/pkgdeps/model.rs` — normalized `Package`, `Dep`, `EdgeKind`, `DepClosure`, `InstallPlan` types with stable serde JSON.
- `src/pkgdeps/source.rs` — `MetadataSource` trait + in-memory `MockSource`.
- `src/pkgdeps/pacman.rs` — production backend; parses `pacman -Si` and `pactree` output; threads pacman config / dbpath / root.
- `src/pkgdeps/resolver.rs` — recursive closure, virtual provider resolution (rewriting edges to the chosen provider), conflicts/replacements, reverse-dep walk, package diff.
- `src/pkgdeps/graph.rs` — Graphviz DOT serializer with edge-kind-coloured edges (matches `pactree -s -g`).
- `src/pkgdeps/cli.rs` — subcommand handlers + offline fixture loader.
- `src/main.rs` — wires `deps` subcommand and shared `--config/--dbpath/--root/--include-*/--json/--dot/--offline` flags.
- `tests/pkgdeps_integration.rs` — end-to-end coverage with a synthetic Artix-style universe.
- `README.md` — new "Package Dependency Tracking" section explaining why pacman/libalpm metadata is preferred over scraping.

## Why pacman, not the website
Scraping `packages.artixlinux.org` is fragile (HTML drift), lags real sync DBs, ignores user `pacman.conf` / repo selection, and cannot answer transaction questions. Using libalpm-style metadata is the same source pacman itself consults at install time.

## Test plan
- [ ] `cargo test --all-features` — unit + integration tests verify direct/recursive resolution, providers, version constraints, optional-dep gating, make/check separation, reverse lookup, install-plan installed-vs-clean-root, DOT output, JSON schema round-trip, and that different pacman configs yield different results.
- [ ] `cargo clippy --all-features -- -D warnings`
- [ ] On a real Artix host: `deploytix deps resolve base`, `deploytix deps graph pacman -o pacman.dot`, `deploytix deps plan-install base --root /mnt --dbpath /mnt/var/lib/pacman --clean-root`.

> Note: the sandbox in which this branch was prepared has no Rust toolchain, so `cargo build`/`cargo test` were not executed locally. The code is structured for testability (mockable `MetadataSource` + `CmdExec`) precisely so CI can validate it where pacman is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)