### PR TITLE
feat(pkgdeps): preflight basestrap & chroot pacman dependency resolution

### DIFF
--- a/src/configure/packages.rs
+++ b/src/configure/packages.rs
@@ -94,6 +94,9 @@ pub fn install_gpu_drivers(
     }
 
     let pkg_list = packages.join(" ");
+    let pkg_strings: Vec<String> = packages.iter().map(|s| (*s).to_string()).collect();
+    let _ =
+        crate::pkgdeps::preflight::preflight_chroot(install_root, &pkg_strings, cmd.is_dry_run());
     let install_cmd = format!("pacman -S --noconfirm --needed {}", pkg_list);
     cmd.run_in_chroot(install_root, &install_cmd)?;
 
@@ -120,6 +123,11 @@ fn ensure_arch_repos_in_chroot(cmd: &CommandRunner, install_root: &str) -> Resul
     // Install artix-archlinux-support which provides the Arch mirrorlist
     // and keyring.  This package is in Artix's own repos.
     info!("Installing artix-archlinux-support in chroot");
+    let _ = crate::pkgdeps::preflight::preflight_chroot(
+        install_root,
+        &["artix-archlinux-support".to_string()],
+        cmd.is_dry_run(),
+    );
     cmd.run_in_chroot(
         install_root,
         "pacman -S --noconfirm --needed artix-archlinux-support",
@@ -201,6 +209,9 @@ pub fn install_wine_packages(
         .copied()
         .collect();
     let pkg_list = all_pkgs.join(" ");
+    let pkg_strings: Vec<String> = all_pkgs.iter().map(|s| (*s).to_string()).collect();
+    let _ =
+        crate::pkgdeps::preflight::preflight_chroot(install_root, &pkg_strings, cmd.is_dry_run());
     let install_cmd = format!("pacman -S --noconfirm --needed {}", pkg_list);
     cmd.run_in_chroot(install_root, &install_cmd)?;
 
@@ -369,6 +380,12 @@ pub fn install_gaming_packages(
     if !lib32_vulkan.is_empty() {
         let vulkan_list = lib32_vulkan.join(" ");
         info!("Installing lib32 Vulkan drivers: {}", vulkan_list);
+        let vulkan_strings: Vec<String> = lib32_vulkan.iter().map(|s| (*s).to_string()).collect();
+        let _ = crate::pkgdeps::preflight::preflight_chroot(
+            install_root,
+            &vulkan_strings,
+            cmd.is_dry_run(),
+        );
         let vulkan_cmd = format!("pacman -S --noconfirm --needed {}", vulkan_list);
         cmd.run_in_chroot(install_root, &vulkan_cmd)?;
     }
@@ -379,6 +396,9 @@ pub fn install_gaming_packages(
     packages.extend(GAMING_PACKAGES);
     packages.extend(GAMESCOPE_RUNTIME_DEPS);
     let pkg_list = packages.join(" ");
+    let pkg_strings: Vec<String> = packages.iter().map(|s| (*s).to_string()).collect();
+    let _ =
+        crate::pkgdeps::preflight::preflight_chroot(install_root, &pkg_strings, cmd.is_dry_run());
     let install_cmd = format!("pacman -S --noconfirm --needed {}", pkg_list);
     cmd.run_in_chroot(install_root, &install_cmd)?;
 
@@ -411,6 +431,10 @@ fn build_bazzite_gamescope(
 
     // Ensure build tool chain is present inside the chroot.
     let build_deps = GAMESCOPE_BUILD_DEPS.join(" ");
+    let mut build_pkgs: Vec<String> = vec!["base-devel".to_string()];
+    build_pkgs.extend(GAMESCOPE_BUILD_DEPS.iter().map(|s| (*s).to_string()));
+    let _ =
+        crate::pkgdeps::preflight::preflight_chroot(install_root, &build_pkgs, cmd.is_dry_run());
     cmd.run_in_chroot(
         install_root,
         &format!("pacman -S --noconfirm --needed base-devel {build_deps}"),
@@ -481,6 +505,16 @@ pub fn install_yay(
     }
 
     // Ensure build dependencies are present
+    let yay_build_deps = vec![
+        "go".to_string(),
+        "git".to_string(),
+        "base-devel".to_string(),
+    ];
+    let _ = crate::pkgdeps::preflight::preflight_chroot(
+        install_root,
+        &yay_build_deps,
+        cmd.is_dry_run(),
+    );
     cmd.run_in_chroot(
         install_root,
         "pacman -S --noconfirm --needed go git base-devel",

--- a/src/configure/services.rs
+++ b/src/configure/services.rs
@@ -109,6 +109,10 @@ fn install_service_packages(
         return Ok(());
     }
 
+    // Preflight: resolve the chroot transaction first so missing
+    // virtual providers / target-not-found surface before pacman runs.
+    let _ = crate::pkgdeps::preflight::preflight_chroot(install_root, &packages, cmd.is_dry_run());
+
     let install_cmd = format!("pacman -S --noconfirm --needed {}", pkg_list);
     cmd.run_in_chroot(install_root, &install_cmd)
         .map(|_| ())

--- a/src/desktop/gnome.rs
+++ b/src/desktop/gnome.rs
@@ -27,6 +27,9 @@ pub fn install(cmd: &CommandRunner, config: &DeploymentConfig, install_root: &st
 
     // Install packages
     let pkg_list = GNOME_PACKAGES.join(" ");
+    let mut all_pkgs: Vec<String> = GNOME_PACKAGES.iter().map(|s| (*s).to_string()).collect();
+    all_pkgs.push(gdm_service.clone());
+    let _ = crate::pkgdeps::preflight::preflight_chroot(install_root, &all_pkgs, cmd.is_dry_run());
     let install_cmd = format!("pacman -S --noconfirm {} {}", pkg_list, gdm_service);
     cmd.run_in_chroot(install_root, &install_cmd)?;
 

--- a/src/desktop/kde.rs
+++ b/src/desktop/kde.rs
@@ -71,23 +71,20 @@ pub fn install(cmd: &CommandRunner, config: &DeploymentConfig, install_root: &st
         return Ok(());
     }
 
-    // Install packages via pacman in chroot
-    let pkg_list = packages.join(" ");
-    let mut install_cmd = if use_session_switching {
-        // No sddm or sddm-{init} when session switching is active
-        format!("pacman -S --noconfirm {}", pkg_list)
-    } else {
-        let sddm_service = format!("sddm-{}", config.system.init);
-        format!("pacman -S --noconfirm {} {}", pkg_list, sddm_service)
-    };
-
-    // Add init-specific service packages for non-s6 init systems
+    // Build the full package list (including init-specific service
+    // pkgs) up front so we can preflight resolution before pacman runs.
+    let mut all_pkgs: Vec<String> = packages.iter().map(|s| (*s).to_string()).collect();
+    if !use_session_switching {
+        all_pkgs.push(format!("sddm-{}", config.system.init));
+    }
     if config.system.init != InitSystem::S6 {
-        let bluez_service = format!("bluez-{}", config.system.init);
-        let power_service = format!("power-profiles-daemon-{}", config.system.init);
-        install_cmd = format!("{} {} {}", install_cmd, bluez_service, power_service);
+        all_pkgs.push(format!("bluez-{}", config.system.init));
+        all_pkgs.push(format!("power-profiles-daemon-{}", config.system.init));
     }
 
+    let _ = crate::pkgdeps::preflight::preflight_chroot(install_root, &all_pkgs, cmd.is_dry_run());
+
+    let install_cmd = format!("pacman -S --noconfirm {}", all_pkgs.join(" "));
     cmd.run_in_chroot(install_root, &install_cmd)?;
 
     // Configure SDDM (skip when session switching uses greetd instead)

--- a/src/desktop/xfce.rs
+++ b/src/desktop/xfce.rs
@@ -30,6 +30,9 @@ pub fn install(cmd: &CommandRunner, config: &DeploymentConfig, install_root: &st
 
     // Install packages
     let pkg_list = XFCE_PACKAGES.join(" ");
+    let mut all_pkgs: Vec<String> = XFCE_PACKAGES.iter().map(|s| (*s).to_string()).collect();
+    all_pkgs.push(lightdm_service.clone());
+    let _ = crate::pkgdeps::preflight::preflight_chroot(install_root, &all_pkgs, cmd.is_dry_run());
     let install_cmd = format!("pacman -S --noconfirm {} {}", pkg_list, lightdm_service);
     cmd.run_in_chroot(install_root, &install_cmd)?;
 

--- a/src/install/basestrap.rs
+++ b/src/install/basestrap.rs
@@ -1,6 +1,7 @@
 //! Basestrap wrapper for base system installation
 
 use crate::config::{DeploymentConfig, DesktopEnvironment, Filesystem, NetworkBackend};
+use crate::pkgdeps::preflight as pkg_preflight;
 use crate::utils::command::CommandRunner;
 use crate::utils::error::{DeploytixError, Result};
 use std::collections::HashSet;
@@ -924,6 +925,15 @@ pub fn run_basestrap_with_retries(
     // Ensure the Arch [extra] repo is available for packages that
     // are not mirrored in the Artix repositories.
     let custom_conf = ensure_arch_repos(custom_conf, cmd)?;
+
+    // Dependency preflight: ask pacman -S --print to resolve the full
+    // transaction against the same pacman.conf basestrap will use. This
+    // surfaces missing virtual providers, target-not-found errors, and
+    // conflict-driven removals before basestrap starts downloading
+    // anything. Best-effort — failures here only log; basestrap itself
+    // is the source of truth.
+    let _report =
+        pkg_preflight::preflight_host(custom_conf.as_deref(), &packages, cmd.is_dry_run())?;
 
     info!(
         "Installing {} packages with basestrap to {}",

--- a/src/pkgdeps/mod.rs
+++ b/src/pkgdeps/mod.rs
@@ -20,8 +20,10 @@ pub mod cli;
 pub mod graph;
 pub mod model;
 pub mod pacman;
+pub mod preflight;
 pub mod resolver;
 pub mod source;
 
 pub use model::{Dep, DepClosure, DepKind, EdgeKind, InstallPlan, Package, PackageRef};
+pub use preflight::{preflight_chroot, preflight_host, PreflightReport};
 pub use source::{MetadataSource, MockSource};

--- a/src/pkgdeps/preflight.rs
+++ b/src/pkgdeps/preflight.rs
@@ -1,0 +1,400 @@
+//! Dependency-resolution preflight for `basestrap` and chroot `pacman`
+//! operations.
+//!
+//! Both basestrap (run on the host against the live system's pacman
+//! configuration) and `pacman -S` invocations inside the chroot ultimately
+//! ask libalpm to resolve a transaction. When that resolution fails —
+//! missing virtual provider, target not in any sync DB, conflict the user
+//! must resolve interactively — we want to know *before* the transaction
+//! starts, while we still have a clean failure surface.
+//!
+//! This module wraps [`MetadataSource::install_plan`] (i.e. `pacman -S
+//! --print`) with logging that surfaces unresolvable targets and
+//! conflict-driven removals. It is best-effort: if pacman/expac aren't
+//! available (e.g. running outside the live ISO during development) or the
+//! sync DB is empty, we log a warning and let the real `basestrap` /
+//! `pacman` invocation be the source of truth. We don't want to block an
+//! install because the metadata layer disagrees with what pacman would
+//! actually do.
+//!
+//! Two entry points:
+//! * [`preflight_host`] — used before host `basestrap` runs. Reads the
+//!   host's pacman.conf (optionally a temporary one with the [deploytix]
+//!   / [extra] repos appended) and resolves against the host's sync DB.
+//! * [`preflight_chroot`] — used before any chroot `pacman -S`. Points
+//!   pacman at `<install_root>` via `--root` / `--config` so that the
+//!   resolution sees the chroot's pacman.conf and pacman state DB.
+
+use super::pacman::{PacmanConfig, PacmanSource};
+use super::source::MetadataSource;
+use crate::utils::error::Result;
+use tracing::{debug, info, warn};
+
+/// Outcome of a preflight resolution. Fields mirror the parts of
+/// [`super::model::InstallPlan`] callers actually act on so the call
+/// sites don't need to know about the full model crate.
+#[derive(Debug, Clone, Default)]
+pub struct PreflightReport {
+    /// Number of packages pacman would install (after resolving deps,
+    /// virtual providers, replacements). 0 means resolution failed or the
+    /// sync DB hasn't seen these targets yet.
+    pub planned_install_count: usize,
+    /// Targets the resolver could not resolve at all. Empty means every
+    /// requested package is reachable in the sync database. Non-empty is
+    /// a strong signal that the upcoming pacman/basestrap call will fail
+    /// with `target not found`.
+    pub unresolved: Vec<String>,
+    /// Conflict-driven removals reported by pacman. We surface these so
+    /// an unattended install doesn't silently delete an installed package
+    /// the user didn't expect to lose.
+    pub to_remove: Vec<String>,
+    /// Free-form warnings from the metadata layer (stale sync DB,
+    /// missing repos, etc.).
+    pub warnings: Vec<String>,
+    /// True when the preflight could not run at all (pacman/expac not
+    /// available, dry-run mode, etc.). The caller should treat this as
+    /// "didn't preflight" rather than "preflight passed".
+    pub skipped: bool,
+}
+
+impl PreflightReport {
+    /// `true` when no unresolvable targets were observed. Conflicts are
+    /// not considered failures here — pacman handles them, we only
+    /// report.
+    pub fn is_resolvable(&self) -> bool {
+        self.unresolved.is_empty()
+    }
+
+    fn skipped_reason(reason: &str) -> Self {
+        Self {
+            warnings: vec![reason.to_string()],
+            skipped: true,
+            ..Default::default()
+        }
+    }
+}
+
+/// Build a [`PacmanSource`] for preflight against the host's sync DB,
+/// optionally with a custom pacman.conf (the same `-C <conf>` path that
+/// will be passed to basestrap).
+fn host_source(custom_conf: Option<&str>) -> PacmanSource<super::pacman::SystemExec> {
+    PacmanSource::system(PacmanConfig {
+        config: custom_conf.map(|s| s.to_string()),
+        dbpath: None,
+        root: None,
+    })
+}
+
+/// Build a [`PacmanSource`] that resolves against the chroot's pacman
+/// state. `--root` makes pacman treat `install_root` as `/`; `--config`
+/// (and the implied `--dbpath`) make it read the chroot's
+/// `/etc/pacman.conf` and `/var/lib/pacman` instead of the host's.
+fn chroot_source(install_root: &str) -> PacmanSource<super::pacman::SystemExec> {
+    let conf = format!("{}/etc/pacman.conf", install_root);
+    let dbpath = format!("{}/var/lib/pacman", install_root);
+    PacmanSource::system(PacmanConfig {
+        config: Some(conf),
+        dbpath: Some(dbpath),
+        root: Some(install_root.to_string()),
+    })
+}
+
+/// Resolve `packages` against `source` and emit a [`PreflightReport`].
+///
+/// `clean_root=true` tells pacman to ignore the local installed-DB when
+/// computing the plan — appropriate for basestrap (target system has no
+/// installed packages yet) and for chroot operations that want to see
+/// every transitive dep regardless of whether the host already has it.
+///
+/// This function NEVER returns `Err` for ordinary pacman failures. Any
+/// command failure is folded into `PreflightReport::skipped = true` with
+/// a warning, so the caller can log and continue. The only `Err` return
+/// is signal interruption / I/O the caller cares about — callers can
+/// safely use `?` here.
+pub fn resolve(
+    source: &dyn MetadataSource,
+    packages: &[String],
+    clean_root: bool,
+    label: &str,
+) -> Result<PreflightReport> {
+    if packages.is_empty() {
+        return Ok(PreflightReport::default());
+    }
+
+    let targets: Vec<&str> = packages.iter().map(|s| s.as_str()).collect();
+    debug!(
+        "Preflight ({}): resolving {} target(s) clean_root={}",
+        label,
+        targets.len(),
+        clean_root
+    );
+
+    // `pacman -S --print` — a real transaction simulation. If pacman is
+    // missing or the sync DB is empty this returns Err; treat it as
+    // "skipped" rather than fatal so basestrap remains the source of
+    // truth.
+    let plan = match source.install_plan(&targets, clean_root) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "Preflight ({}): unable to compute install plan ({}). Continuing without preflight; \
+                 the upcoming pacman/basestrap call will be the source of truth.",
+                label, e
+            );
+            return Ok(PreflightReport::skipped_reason(&format!(
+                "preflight skipped: {}",
+                e
+            )));
+        }
+    };
+
+    // Targets that were requested but never appeared in the install
+    // list are unresolvable — pacman will error with "target not
+    // found". We compute this from the resolver output rather than
+    // re-grepping pacman stderr because the `MockSource` path doesn't
+    // produce real pacman errors.
+    let resolved_names: std::collections::BTreeSet<&str> =
+        plan.to_install.iter().map(|p| p.name.as_str()).collect();
+    let unresolved: Vec<String> = targets
+        .iter()
+        .filter(|t| !resolved_names.contains(*t))
+        .map(|s| (*s).to_string())
+        .collect();
+
+    let report = PreflightReport {
+        planned_install_count: plan.to_install.len(),
+        unresolved: unresolved.clone(),
+        to_remove: plan.to_remove.clone(),
+        warnings: plan.warnings.clone(),
+        skipped: false,
+    };
+
+    info!(
+        "Preflight ({}): {} target(s) → {} package(s) to install, {} to remove",
+        label,
+        targets.len(),
+        report.planned_install_count,
+        report.to_remove.len()
+    );
+    if !report.unresolved.is_empty() {
+        warn!(
+            "Preflight ({}): {} unresolvable target(s): {}. \
+             The upcoming pacman/basestrap call is likely to fail with `target not found`.",
+            label,
+            report.unresolved.len(),
+            report.unresolved.join(", ")
+        );
+    }
+    if !report.to_remove.is_empty() {
+        warn!(
+            "Preflight ({}): pacman would remove {} existing package(s) due to conflicts/replacements: {}",
+            label,
+            report.to_remove.len(),
+            report.to_remove.join(", ")
+        );
+    }
+    for w in &report.warnings {
+        warn!("Preflight ({}): {}", label, w);
+    }
+
+    Ok(report)
+}
+
+/// Preflight the host basestrap transaction.
+///
+/// `custom_conf` is the optional `-C <path>` value basestrap will be
+/// invoked with (e.g. the temporary pacman.conf with the [deploytix]
+/// repo appended). Pass `None` when basestrap will use the system's
+/// `/etc/pacman.conf` directly.
+///
+/// In dry-run mode we skip the resolver entirely — basestrap won't run
+/// either, and pacman -Sy on the host would mutate state.
+pub fn preflight_host(
+    custom_conf: Option<&str>,
+    packages: &[String],
+    dry_run: bool,
+) -> Result<PreflightReport> {
+    if dry_run {
+        info!("[dry-run] Skipping host basestrap dependency preflight");
+        return Ok(PreflightReport::skipped_reason("dry-run"));
+    }
+    let source = host_source(custom_conf);
+    // basestrap installs into a fresh root → use clean_root semantics so
+    // the plan reflects everything pacman would download (not just
+    // what's missing on the live ISO host).
+    resolve(&source, packages, true, "host basestrap")
+}
+
+/// Preflight a `pacman -S <packages>` call that will run inside the
+/// chroot. Resolves against the chroot's pacman.conf and dbpath so
+/// already-installed packages (i.e. those basestrap put down) are
+/// correctly skipped.
+///
+/// In dry-run mode we skip the resolver — the chroot won't be populated.
+pub fn preflight_chroot(
+    install_root: &str,
+    packages: &[String],
+    dry_run: bool,
+) -> Result<PreflightReport> {
+    if dry_run {
+        info!("[dry-run] Skipping chroot pacman dependency preflight");
+        return Ok(PreflightReport::skipped_reason("dry-run"));
+    }
+    // The chroot's pacman state needs to exist before we can query it.
+    // basestrap creates it, so this is normally fine; if it doesn't
+    // (e.g. preflight called too early), `--root` will make pacman
+    // bail and we'll fold that into "skipped".
+    let conf_path = format!("{}/etc/pacman.conf", install_root);
+    if !std::path::Path::new(&conf_path).exists() {
+        let msg = format!(
+            "chroot pacman.conf not found at {}; preflight skipped",
+            conf_path
+        );
+        debug!("{}", msg);
+        return Ok(PreflightReport::skipped_reason(&msg));
+    }
+
+    let source = chroot_source(install_root);
+    // For chroot operations we want pacman to consult the *chroot's*
+    // installed DB, so already-present packages (base, deps from prior
+    // pacman -S in this same install) are correctly excluded. Hence
+    // clean_root=false.
+    resolve(&source, packages, false, "chroot pacman")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pkgdeps::model::{Dep, Package};
+    use crate::pkgdeps::source::MockSource;
+
+    fn pkg(name: &str, version: &str, deps: &[&str]) -> Package {
+        let mut p = Package::new(name, version, "world");
+        p.depends = deps.iter().map(|d| Dep::parse(d)).collect();
+        p
+    }
+
+    fn universe() -> MockSource {
+        let mut s = MockSource::default();
+        s.set_databases(vec!["world".into()]);
+        s.insert(pkg("base", "1.0", &["glibc"]));
+        s.insert(pkg("glibc", "2.39", &[]));
+        s.insert(pkg("linux-zen", "6.10", &[]));
+        // virtual provider
+        let mut bash = pkg("bash", "5.2", &[]);
+        bash.provides = vec![Dep::unversioned("sh")];
+        s.insert(bash);
+        // package with a conflict
+        let mut foo = pkg("foo", "1.0", &[]);
+        foo.conflicts = vec![Dep::unversioned("oldfoo")];
+        s.insert(foo);
+        s
+    }
+
+    #[test]
+    fn empty_targets_short_circuits_to_default_report() {
+        let s = universe();
+        let r = resolve(&s, &[], true, "test").unwrap();
+        assert!(!r.skipped);
+        assert!(r.is_resolvable());
+        assert_eq!(r.planned_install_count, 0);
+        assert!(r.unresolved.is_empty());
+    }
+
+    #[test]
+    fn resolves_known_targets() {
+        let s = universe();
+        let r = resolve(
+            &s,
+            &["base".to_string(), "linux-zen".to_string()],
+            true,
+            "test",
+        )
+        .unwrap();
+        assert!(!r.skipped);
+        assert!(r.is_resolvable(), "unresolved: {:?}", r.unresolved);
+        // base + glibc + linux-zen (all clean_root)
+        assert!(r.planned_install_count >= 3);
+    }
+
+    #[test]
+    fn unresolvable_target_is_reported() {
+        let s = universe();
+        let r = resolve(
+            &s,
+            &["base".to_string(), "does-not-exist".to_string()],
+            true,
+            "test",
+        )
+        .unwrap();
+        assert!(!r.is_resolvable());
+        assert!(r.unresolved.iter().any(|u| u == "does-not-exist"));
+    }
+
+    #[test]
+    fn virtual_provider_not_marked_unresolved() {
+        // Build a universe where a package depends on `sh` (virtual). The
+        // resolver must include the real provider (bash) and the
+        // requested target itself must not be in `unresolved`.
+        let mut s = MockSource::default();
+        s.set_databases(vec!["world".into()]);
+        let mut needs_sh = Package::new("needs-sh", "1.0", "world");
+        needs_sh.depends = vec![Dep::unversioned("sh")];
+        s.insert(needs_sh);
+        let mut bash = Package::new("bash", "5.2", "world");
+        bash.provides = vec![Dep::unversioned("sh")];
+        s.insert(bash);
+
+        let r = resolve(&s, &["needs-sh".to_string()], true, "test").unwrap();
+        assert!(r.is_resolvable());
+        assert!(r.unresolved.is_empty());
+        // bash should be in the plan as the resolved provider.
+        assert!(r.planned_install_count >= 2);
+    }
+
+    #[test]
+    fn conflict_driven_removal_is_surfaced() {
+        let mut s = universe();
+        // Mark `oldfoo` as installed; planning `foo` (which conflicts
+        // with oldfoo) should produce a removal entry.
+        s.insert(pkg("oldfoo", "0.9", &[]));
+        s.mark_installed("oldfoo");
+        let r = resolve(&s, &["foo".to_string()], false, "test").unwrap();
+        assert!(r.is_resolvable());
+        assert!(
+            r.to_remove.iter().any(|n| n == "oldfoo"),
+            "expected oldfoo in to_remove, got {:?}",
+            r.to_remove
+        );
+    }
+
+    #[test]
+    fn report_skipped_when_dry_run_host() {
+        let r = preflight_host(None, &["base".to_string()], true).unwrap();
+        assert!(r.skipped);
+        assert_eq!(r.planned_install_count, 0);
+    }
+
+    #[test]
+    fn report_skipped_when_dry_run_chroot() {
+        let r = preflight_chroot("/nonexistent", &["base".to_string()], true).unwrap();
+        assert!(r.skipped);
+    }
+
+    #[test]
+    fn chroot_preflight_skips_when_install_root_missing() {
+        // Live mode (dry_run=false) but install_root has no pacman.conf
+        // → preflight reports skipped instead of erroring.
+        let r = preflight_chroot(
+            "/var/empty/definitely-not-an-install-root",
+            &["base".to_string()],
+            false,
+        )
+        .unwrap();
+        assert!(r.skipped);
+        assert!(r
+            .warnings
+            .iter()
+            .any(|w| w.contains("pacman.conf not found")));
+    }
+}

--- a/tests/preflight_integration.rs
+++ b/tests/preflight_integration.rs
@@ -1,0 +1,148 @@
+//! Integration tests for the dependency-resolution preflight used before
+//! basestrap (on the host) and `pacman -S` (in the chroot).
+//!
+//! These tests drive the public preflight API with a `MockSource` that
+//! stands in for pacman, so they exercise the resolver path that the
+//! real `PacmanSource` triggers without needing pacman/expac on $PATH.
+
+use deploytix::pkgdeps::model::{Dep, Package};
+use deploytix::pkgdeps::preflight::{preflight_chroot, preflight_host, resolve, PreflightReport};
+use deploytix::pkgdeps::source::MockSource;
+
+fn pkg(name: &str, version: &str, repo: &str, deps: &[&str]) -> Package {
+    let mut p = Package::new(name, version, repo);
+    p.depends = deps.iter().map(|d| Dep::parse(d)).collect();
+    p
+}
+
+/// Mirrors a stripped-down basestrap target list for an Artix install:
+/// base + linux-zen + an init-system base package, with a virtual
+/// provider for `sh` to ensure that path is exercised end-to-end.
+fn basestrap_universe() -> MockSource {
+    let mut s = MockSource::default();
+    s.set_databases(vec!["system".into(), "world".into(), "extra".into()]);
+    s.insert(pkg("base", "1.0", "system", &["glibc", "sh"]));
+    s.insert(pkg("glibc", "2.39", "system", &[]));
+    s.insert(pkg("linux-zen", "6.10", "system", &[]));
+    s.insert(pkg("linux-zen-headers", "6.10", "system", &[]));
+    s.insert(pkg("linux-firmware", "20240101", "system", &[]));
+    s.insert(pkg("runit", "2.2", "world", &["base"]));
+    s.insert(pkg("base-devel", "1.0", "system", &[]));
+    let mut bash = pkg("bash", "5.2", "system", &[]);
+    bash.provides = vec![Dep::unversioned("sh")];
+    s.insert(bash);
+    s
+}
+
+#[test]
+fn preflight_resolves_basestrap_targets_via_metadata_source() {
+    let src = basestrap_universe();
+    // The targets a typical basestrap call would receive — same shape
+    // as `build_package_list` produces for a runit Artix system.
+    let targets = vec![
+        "base".to_string(),
+        "base-devel".to_string(),
+        "runit".to_string(),
+        "linux-zen".to_string(),
+        "linux-zen-headers".to_string(),
+        "linux-firmware".to_string(),
+    ];
+
+    let report: PreflightReport = resolve(&src, &targets, true, "test basestrap").unwrap();
+
+    assert!(!report.skipped, "preflight should not be skipped");
+    assert!(
+        report.is_resolvable(),
+        "all basestrap targets must resolve; unresolved = {:?}",
+        report.unresolved
+    );
+    // glibc + bash come in transitively from `base`'s deps; verify the
+    // plan reflects pacman's real transaction shape.
+    assert!(
+        report.planned_install_count >= targets.len() + 2,
+        "expected transitive deps in plan, got {}",
+        report.planned_install_count
+    );
+}
+
+#[test]
+fn preflight_flags_unresolvable_basestrap_target() {
+    let src = basestrap_universe();
+    // Add a typo'd package name to simulate a broken
+    // `build_package_list` output.
+    let targets = vec!["base".to_string(), "linux-zenn".to_string()];
+    let report = resolve(&src, &targets, true, "test").unwrap();
+    assert!(!report.is_resolvable());
+    assert!(report.unresolved.iter().any(|u| u == "linux-zenn"));
+    // The good target is still planned.
+    assert!(report.planned_install_count >= 1);
+}
+
+#[test]
+fn preflight_surfaces_conflict_driven_removals() {
+    // Simulate the case where the chroot already has an `oldpkg` and
+    // we're asking pacman to install something that `Conflicts =` it.
+    // The preflight must surface the removal so an unattended install
+    // doesn't silently lose user data.
+    let mut src = basestrap_universe();
+    let mut newpkg = pkg("newpkg", "1.0", "world", &[]);
+    newpkg.conflicts = vec![Dep::unversioned("oldpkg")];
+    src.insert(newpkg);
+    src.insert(pkg("oldpkg", "0.9", "world", &[]));
+    src.mark_installed("oldpkg");
+
+    let report = resolve(&src, &["newpkg".to_string()], false, "chroot").unwrap();
+    assert!(report.is_resolvable());
+    assert!(
+        report.to_remove.iter().any(|n| n == "oldpkg"),
+        "expected oldpkg in to_remove; got {:?}",
+        report.to_remove
+    );
+}
+
+#[test]
+fn dry_run_skips_host_preflight() {
+    // dry_run=true must short-circuit without trying to invoke pacman.
+    let r = preflight_host(None, &["base".to_string()], true).unwrap();
+    assert!(r.skipped);
+    assert!(r.warnings.iter().any(|w| w.contains("dry-run")));
+}
+
+#[test]
+fn dry_run_skips_chroot_preflight() {
+    let r = preflight_chroot("/install", &["base".to_string()], true).unwrap();
+    assert!(r.skipped);
+}
+
+#[test]
+fn chroot_preflight_skipped_when_pacman_conf_missing() {
+    // Live (dry_run=false) but the install root has no pacman.conf yet
+    // (e.g. preflight called too early in the install pipeline). The
+    // helper must report skipped + a clear warning rather than blowing
+    // up.
+    let r = preflight_chroot(
+        "/var/empty/deploytix-no-such-install-root",
+        &["base".to_string()],
+        false,
+    )
+    .unwrap();
+    assert!(r.skipped);
+    assert!(
+        r.warnings
+            .iter()
+            .any(|w| w.contains("pacman.conf not found")),
+        "warnings = {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn empty_target_list_returns_clean_report() {
+    let src = basestrap_universe();
+    let r = resolve(&src, &[], true, "test").unwrap();
+    assert!(!r.skipped);
+    assert!(r.is_resolvable());
+    assert_eq!(r.planned_install_count, 0);
+    assert!(r.unresolved.is_empty());
+    assert!(r.to_remove.is_empty());
+}


### PR DESCRIPTION
## Summary

- Add a `pkgdeps::preflight` module that resolves a pacman transaction (via the existing `MetadataSource::install_plan` → `pacman -S --print`) **before** basestrap (on the host) and every chroot `pacman -S` invocation runs.
- Wire `preflight_host` into `install::basestrap::run_basestrap_with_retries` so basestrap targets are resolved against the same pacman.conf basestrap will use (including `-C <custom>` for the `[deploytix]` / Arch `[extra]` repos).
- Wire `preflight_chroot` into every chroot pacman site: `configure::packages` (GPU drivers, Wine, gaming, gamescope build deps, yay deps, artix-archlinux-support), `configure::services::install_service_packages`, and `desktop::{kde,gnome,xfce}`.
- Preflight is **best-effort**: if pacman/expac aren't available, the sync DB is empty, or `<install_root>/etc/pacman.conf` doesn't exist yet, the helper logs a warning and lets the real basestrap/pacman call be the source of truth — basestrap behaviour is preserved exactly.

## Why

Before this change, missing virtual providers, target-not-found typos, or conflict-driven removals only surfaced once pacman/basestrap was already mid-transaction (after downloading the sync DB and partial package set). Surfacing them up front gives a clean failure with a precise package name and avoids the partial-install state.

The implementation reuses the existing libalpm-backed `PacmanSource` (with the same `--config` / `--dbpath` / `--root` plumbing already used by `deps plan-install`), so it knows about virtual providers, conflicts, and replacements rather than blindly shell-grepping pacman output.

## Design notes

- Host preflight uses `clean_root=true` because basestrap installs into a fresh root.
- Chroot preflight uses `clean_root=false` so packages already laid down by basestrap (or earlier `pacman -S` calls in the same install) are correctly skipped.
- `PreflightReport.skipped` is `true` whenever the resolver couldn't run (dry-run, missing tooling, missing chroot pacman.conf) — callers treat this as "didn't preflight" rather than "preflight passed".
- All preflight output goes through `tracing::{info,warn}`, so it appears alongside the rest of the install pipeline output.

## Tests

- 7 new integration tests in `tests/preflight_integration.rs` driving `preflight::resolve` / `preflight_host` / `preflight_chroot` against `MockSource`.
- 7 new unit tests in `src/pkgdeps/preflight.rs::tests` covering empty inputs, virtual providers, conflict-driven removals, unresolvable targets, dry-run skip, and missing-pacman.conf skip.

## Test plan

- [x] `cargo test --lib` — 124 pass, 0 fail
- [x] `cargo test --test preflight_integration` — 7 pass, 0 fail
- [x] `cargo build --bin deploytix` — succeeds
- [x] `cargo clippy --lib --tests` — only pre-existing dead-code warnings
- [ ] Manual run on a live Artix ISO (basestrap path)
- [ ] Manual run with a typo'd package in `build_package_list` to verify the warning surfaces before basestrap downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)