### PR TITLE
fix(audio): suppress ALSA PCM underrun spam during installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ name = "deploytix"
 version = "1.2.0"
 dependencies = [
  "anyhow",
+ "cc",
  "clap",
  "colored",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ name = "deploytix-gui"
 path = "src/gui_main.rs"
 required-features = ["gui"]
 
+[build-dependencies]
+cc = "1"
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+fn main() {
+    #[cfg(target_os = "linux")]
+    {
+        let out = std::env::var("OUT_DIR").unwrap();
+
+        cc::Build::new()
+            .file("src/resources/alsa_noop.c")
+            .compile("alsa_noop");
+
+        // cc::Build::compile emits rustc-link-lib + rustc-link-search, but in a
+        // package with both a lib and a bin target Cargo sometimes propagates the
+        // search path without the library name.  Passing the archive as a direct
+        // linker argument is unconditional and avoids the propagation gap.
+        println!("cargo:rustc-link-arg={out}/libalsa_noop.a");
+        println!("cargo:rerun-if-changed=src/resources/alsa_noop.c");
+    }
+}

--- a/src/resources/alsa_noop.c
+++ b/src/resources/alsa_noop.c
@@ -1,0 +1,13 @@
+#include <alsa/asoundlib.h>
+
+static void noop_handler(
+    const char *file, int line, const char *function,
+    int err, const char *fmt, ...)
+{
+    (void)file; (void)line; (void)function; (void)err; (void)fmt;
+}
+
+void deploytix_suppress_alsa_errors(void)
+{
+    snd_lib_error_set_handler(noop_handler);
+}

--- a/src/resources/audio.rs
+++ b/src/resources/audio.rs
@@ -13,6 +13,38 @@ pub struct AudioHandle {
     _sink: rodio::Sink,
 }
 
+/// Install a no-op ALSA error handler to suppress PCM underrun spam.
+///
+/// During heavy disk I/O the audio buffer starves, causing ALSA's default
+/// handler to print "underrun occurred" to stderr on every glitch. A no-op
+/// handler silences the output without changing ALSA's recovery behaviour.
+/// libasound is already in the link path via rodio → cpal → alsa-sys.
+#[cfg(target_os = "linux")]
+fn suppress_alsa_errors() {
+    use std::ffi::{c_char, c_int};
+
+    type AlsaHandler =
+        unsafe extern "C" fn(*const c_char, c_int, *const c_char, c_int, *const c_char);
+
+    unsafe extern "C" fn noop(
+        _: *const c_char,
+        _: c_int,
+        _: *const c_char,
+        _: c_int,
+        _: *const c_char,
+    ) {
+    }
+
+    extern "C" {
+        fn snd_lib_error_set_handler(handler: Option<AlsaHandler>);
+    }
+
+    unsafe { snd_lib_error_set_handler(Some(noop)) };
+}
+
+#[cfg(not(target_os = "linux"))]
+fn suppress_alsa_errors() {}
+
 /// Ensure the audio server is reachable when running as root via sudo/pkexec.
 ///
 /// PipeWire and PulseAudio live in the invoking user's XDG_RUNTIME_DIR.
@@ -47,6 +79,7 @@ fn ensure_audio_env() {
 /// Returns a handle that must be kept alive for playback to continue.
 /// Returns `None` if audio initialization fails (e.g., no audio device).
 pub fn play_theme_loop() -> Option<AudioHandle> {
+    suppress_alsa_errors();
     ensure_audio_env();
 
     let (stream, stream_handle) = match rodio::OutputStream::try_default() {

--- a/src/resources/audio.rs
+++ b/src/resources/audio.rs
@@ -18,28 +18,16 @@ pub struct AudioHandle {
 /// During heavy disk I/O the audio buffer starves, causing ALSA's default
 /// handler to print "underrun occurred" to stderr on every glitch. A no-op
 /// handler silences the output without changing ALSA's recovery behaviour.
-/// libasound is already in the link path via rodio → cpal → alsa-sys.
+///
+/// The handler is registered through a C shim (alsa_noop.c) so the variadic
+/// callback signature `void(*)(const char*, int, const char*, int, const char*, ...)`
+/// is expressed in C, which avoids the Rust-stable limitation on variadic fn pointers.
 #[cfg(target_os = "linux")]
 fn suppress_alsa_errors() {
-    use std::ffi::{c_char, c_int};
-
-    type AlsaHandler =
-        unsafe extern "C" fn(*const c_char, c_int, *const c_char, c_int, *const c_char);
-
-    unsafe extern "C" fn noop(
-        _: *const c_char,
-        _: c_int,
-        _: *const c_char,
-        _: c_int,
-        _: *const c_char,
-    ) {
-    }
-
     extern "C" {
-        fn snd_lib_error_set_handler(handler: Option<AlsaHandler>);
+        fn deploytix_suppress_alsa_errors();
     }
-
-    unsafe { snd_lib_error_set_handler(Some(noop)) };
+    unsafe { deploytix_suppress_alsa_errors() };
 }
 
 #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
During heavy disk I/O (LUKS formatting, partitioning), the audio buffer
starves and ALSA's default error handler floods stderr with repeated
"snd_pcm_recover [error.pcm] underrun occurred" messages. Install a
no-op snd_lib_error_set_handler at audio startup to silence the output;
ALSA still recovers from underruns internally — only the stderr noise is
suppressed.

https://claude.ai/code/session_0117RHLzHA8uPDczLoePK2QF