### PR TITLE
Clear stale filesystem signatures before formatting partitions

### DIFF
--- a/src/disk/formatting.rs
+++ b/src/disk/formatting.rs
@@ -17,6 +17,12 @@ pub fn format_partition(
 ) -> Result<()> {
     info!("Formatting {} as {}", partition, filesystem);
 
+    // Clear stale filesystem/LUKS signatures so the kernel probes the new
+    // filesystem correctly.  mkfs tools write their superblock at offsets
+    // above 0 (btrfs at 64 KiB, ext4 at 1 KiB), leaving an old LUKS2 header
+    // at byte 0 intact, which causes `mount` to see crypto_LUKS instead.
+    let _ = cmd.run("wipefs", &["-a", partition]);
+
     let label_args: Vec<&str> = match (filesystem, label) {
         (Filesystem::Ext4, Some(l)) => vec!["-L", l],
         (Filesystem::Btrfs, Some(l)) => vec!["-L", l],
@@ -83,6 +89,7 @@ pub fn format_partition(
 pub fn format_efi(cmd: &CommandRunner, partition: &str) -> Result<()> {
     info!("Formatting {} as FAT32 (EFI)", partition);
 
+    let _ = cmd.run("wipefs", &["-a", partition]);
     cmd.run("mkfs.vfat", &["-F32", "-n", "EFI", partition])
         .map(|_| ())
         .map_err(|e| {
@@ -117,6 +124,7 @@ pub fn format_boot_partition(
 pub fn format_swap(cmd: &CommandRunner, partition: &str, label: Option<&str>) -> Result<()> {
     info!("Formatting {} as swap", partition);
 
+    let _ = cmd.run("wipefs", &["-a", partition]);
     let mut args = vec![];
     if let Some(l) = label {
         args.extend(["-L", l]);
@@ -206,6 +214,12 @@ pub fn format_all_partitions(
             format_partition(cmd, &part_path, filesystem, Some(&part.name))?;
         }
     }
+
+    // Flush all pending writes and let udev update device metadata before
+    // the caller tries to mount.  On virtual block devices (NBD, loop) the
+    // kernel page-cache may not have been flushed to the backing store yet.
+    let _ = cmd.run("sync", &[]);
+    let _ = cmd.run("udevadm", &["settle"]);
 
     info!("All partitions formatted successfully");
     Ok(())


### PR DESCRIPTION
## Summary

Add `wipefs -a` calls before formatting partitions to clear stale filesystem and LUKS signatures, ensuring the kernel correctly probes newly formatted filesystems. Also add `sync` and `udevadm settle` at the end of `format_all_partitions()` to flush pending writes and update device metadata.

## Key Changes

- **`format_partition()`**: Call `wipefs -a` before mkfs to remove old LUKS2 headers and other stale signatures that could interfere with filesystem detection
- **`format_efi()`**: Call `wipefs -a` before `mkfs.vfat` to clear any previous filesystem metadata
- **`format_swap()`**: Call `wipefs -a` before mkswap to ensure a clean swap partition
- **`format_all_partitions()`**: Add `sync` and `udevadm settle` at the end to flush kernel page-cache writes (especially important for virtual block devices like NBD and loop) and allow udev to update device metadata before the caller attempts to mount

## Implementation Details

The `wipefs -a` calls use `let _ = cmd.run(...)` to ignore errors, since the partition may not have any signatures to clear on first-time formatting. This is a safe no-op pattern consistent with the codebase.

The final `sync` and `udevadm settle` ensure that on virtual block devices (NBD, loop), pending writes are flushed to the backing store and device metadata is refreshed before mount operations proceed.

https://claude.ai/code/session_015qAdjUorKn1jdUMKtXPri8