### PR TITLE
Add gamescope update utility for gaming deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Common flags: `--config <path>`, `--dbpath <path>`, `--root <path>`, `--include-
 The `[packages]` section provides a full gaming/handheld device stack:
 
 - **Steam + Gamescope** — Installs Steam and builds the Bazzite-maintained gamescope compositor from vendored source (`vendor/gamescope`).
+- **Gamescope Updates** — Deploys `deploytix-update-gamescope` (with an "Update Gamescope" desktop entry) which rebuilds gamescope from the same fork with the exact same meson options every time. AUR rebuilds of gamescope break the Steam session, so a pacman hook aborts any gamescope update not made through this tool and `IgnorePkg = gamescope-git` keeps `-Syu` from touching it.
 - **Session Switching** — Deploys greetd-based scripts for switching between a gamescope (Steam Deck-style) session and a desktop session. Includes `deploytix-session-manager`, `session-select`, `return-to-gamemode`, PAM configs, and a `steamos-session-select` compatibility symlink.
 - **Handheld Daemon (HHD)** — Gamepad remapping, TDP control, per-game profiles (AUR: `hhd-git`). Writes init-specific service files.
 - **Decky Loader** — Steam plugin framework (AUR: `decky-loader-bin`). Writes init-specific service files.

--- a/docs/deploytix-overview.md
+++ b/docs/deploytix-overview.md
@@ -264,6 +264,7 @@ Cargo.toml
 | `iso/profile/deploytix/live-overlay/usr/share/grub/cfg/{defaults,kernels}.cfg` | GRUB cfg | Live-ISO bootloader configuration |
 | `iso/profile/deploytix/root-overlay/etc/mkinitcpio.conf.d/cow-persistence.conf` | mkinitcpio | COW persistence for the live ISO |
 | `iso/gamescope-pkg/PKGBUILD` | Bash | Custom gamescope build for the [deploytix] repo |
+| `src/resources/gamescope_update/PKGBUILD` | Bash | Canonical gamescope rebuild for deployed systems (`deploytix-update-gamescope`); same meson options, https source |
 | `pkg/PKGBUILD` | Bash | `deploytix-git` and `deploytix-gui-git` Arch packages |
 
 The TOML schema is exhaustively defined by serde-derive on `DeploymentConfig` and its sub-structs in `src/config/deployment.rs`; every field has a `#[serde(default = "…")]` so a minimal config is accepted.

--- a/src/configure/gamescope_update.rs
+++ b/src/configure/gamescope_update.rs
@@ -1,0 +1,126 @@
+//! Gamescope update utility deployment
+//!
+//! `gamescope-git` on deployed systems is the Bazzite-maintained fork built
+//! with a specific set of meson options (installed during basestrap from the
+//! custom \[deploytix\] repository).  Updating it through the AUR replaces it
+//! with the upstream Valve build, compiled with different options, which
+//! breaks the Steam gamescope session.
+//!
+//! This module deploys the canonical update path to the target:
+//! - `deploytix-update-gamescope` — rebuilds gamescope from the same
+//!   fork/branch with the exact same PKGBUILD (and thus the exact same meson
+//!   options) every time, then installs it via `pacman -U`.
+//! - The canonical PKGBUILD at `/usr/share/deploytix/gamescope/PKGBUILD`
+//!   (kept in sync with `vendor/gamescope/pkg/PKGBUILD`; only the source URL
+//!   differs — the public https remote instead of a local `git+file://`).
+//! - A desktop entry so the update can be launched from the application menu.
+//! - A pacman `PreTransaction` hook that aborts any gamescope
+//!   install/upgrade not initiated by the update utility.
+//! - `IgnorePkg = gamescope-git` in the target's `pacman.conf` so `pacman
+//!   -Syu` / `yay -Syu` never try to replace the package on their own.
+
+use crate::config::DeploymentConfig;
+use crate::utils::command::CommandRunner;
+use crate::utils::error::Result;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use tracing::info;
+
+// Embedded resources (compiled into the binary)
+const UPDATE_SCRIPT: &str =
+    include_str!("../resources/gamescope_update/deploytix-update-gamescope.sh");
+const CANONICAL_PKGBUILD: &str = include_str!("../resources/gamescope_update/PKGBUILD");
+const DESKTOP_ENTRY: &str =
+    include_str!("../resources/gamescope_update/deploytix-update-gamescope.desktop");
+const GUARD_HOOK: &str =
+    include_str!("../resources/gamescope_update/deploytix-gamescope-guard.hook");
+const GUARD_SCRIPT: &str = include_str!("../resources/gamescope_update/gamescope-guard.sh");
+
+/// File to deploy with its destination path (relative to install root) and permissions
+struct DeployFile {
+    dest: &'static str,
+    content: &'static str,
+    mode: u32,
+}
+
+const DEPLOY_FILES: &[DeployFile] = &[
+    DeployFile {
+        dest: "usr/bin/deploytix-update-gamescope",
+        content: UPDATE_SCRIPT,
+        mode: 0o755,
+    },
+    DeployFile {
+        dest: "usr/share/deploytix/gamescope/PKGBUILD",
+        content: CANONICAL_PKGBUILD,
+        mode: 0o644,
+    },
+    DeployFile {
+        dest: "usr/share/deploytix/gamescope/gamescope-guard.sh",
+        content: GUARD_SCRIPT,
+        mode: 0o755,
+    },
+    DeployFile {
+        dest: "usr/share/libalpm/hooks/deploytix-gamescope-guard.hook",
+        content: GUARD_HOOK,
+        mode: 0o644,
+    },
+    DeployFile {
+        dest: "usr/share/applications/deploytix-update-gamescope.desktop",
+        content: DESKTOP_ENTRY,
+        mode: 0o644,
+    },
+];
+
+/// Deploy the gamescope update utility, canonical PKGBUILD, desktop entry,
+/// and update guard to the target system.
+///
+/// Only meaningful on gaming deployments — `gamescope-git` is installed
+/// during basestrap when `install_gaming` is enabled.
+pub fn setup_gamescope_update(
+    cmd: &CommandRunner,
+    config: &DeploymentConfig,
+    install_root: &str,
+) -> Result<()> {
+    if !config.packages.install_gaming {
+        return Ok(());
+    }
+
+    info!("Deploying gamescope update utility to {}", install_root);
+
+    if cmd.is_dry_run() {
+        for file in DEPLOY_FILES {
+            println!(
+                "  [dry-run] Would install /{} (mode {:o})",
+                file.dest, file.mode
+            );
+        }
+        println!("  [dry-run] Would add 'IgnorePkg = gamescope-git' to /etc/pacman.conf");
+        return Ok(());
+    }
+
+    for file in DEPLOY_FILES {
+        let full_path = format!("{}/{}", install_root, file.dest);
+
+        if let Some(parent) = std::path::Path::new(&full_path).parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::write(&full_path, file.content)?;
+        fs::set_permissions(&full_path, fs::Permissions::from_mode(file.mode))?;
+
+        info!("  Installed {} (mode {:o})", file.dest, file.mode);
+    }
+
+    // Keep pacman/yay from ever replacing the custom build on -Syu.  The
+    // PreTransaction hook already blocks explicit installs; IgnorePkg makes
+    // routine system upgrades skip the package silently instead of failing.
+    cmd.run_in_chroot(
+        install_root,
+        "grep -q '^IgnorePkg *= *gamescope-git' /etc/pacman.conf || \
+         sed -i '/^\\[options\\]/a IgnorePkg = gamescope-git' /etc/pacman.conf",
+    )?;
+    info!("  Added IgnorePkg = gamescope-git to pacman.conf");
+
+    info!("Gamescope update utility deployed successfully");
+    Ok(())
+}

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod bootloader;
 pub mod encryption;
+pub mod gamescope_update;
 pub mod greetd;
 pub mod hooks;
 pub mod keyfiles;

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -302,6 +302,12 @@ impl Installer {
             self.install_gaming_packages()?;
         }
 
+        // Phase 5.22: Gamescope update utility (after gaming packages)
+        if self.config.packages.install_gaming {
+            self.report_progress(0.855, "Installing gamescope update utility...");
+            self.install_gamescope_update()?;
+        }
+
         // Phase 5.25: Session switching scripts (after gaming packages)
         if self.config.packages.install_session_switching {
             self.report_progress(0.86, "Installing session switching scripts...");
@@ -847,6 +853,12 @@ impl Installer {
     fn install_gaming_packages(&self) -> Result<()> {
         info!("Installing gaming packages");
         configure::packages::install_gaming_packages(&self.cmd, &self.config, INSTALL_ROOT)
+    }
+
+    /// Install the gamescope update utility (canonical rebuild + AUR guard)
+    fn install_gamescope_update(&self) -> Result<()> {
+        info!("Installing gamescope update utility");
+        configure::gamescope_update::setup_gamescope_update(&self.cmd, &self.config, INSTALL_ROOT)
     }
 
     /// Install session switching scripts (gamescope ↔ desktop)

--- a/src/resources/gamescope_update/PKGBUILD
+++ b/src/resources/gamescope_update/PKGBUILD
@@ -1,0 +1,115 @@
+# Maintainer: Deploytix
+# Bazzite-maintained gamescope fork (github.com/bazzite-org/gamescope)
+#
+# Canonical PKGBUILD used by `deploytix-update-gamescope` on deployed
+# systems.  It rebuilds gamescope from the same fork and branch, with the
+# exact same meson options, as the package deploytix installed from the
+# [deploytix] repository — the AUR gamescope builds the upstream Valve
+# source with different options and breaks the Steam gamescope session.
+#
+# MUST stay in sync with vendor/gamescope/pkg/PKGBUILD (the ISO build
+# copy); only the source URL differs (https here, git+file:// there).
+
+pkgname=gamescope-git
+pkgver=r2512.c31743d
+pkgrel=1
+pkgdesc='SteamOS session compositing window manager (Bazzite fork)'
+arch=('x86_64')
+url='https://github.com/bazzite-org/gamescope'
+license=('BSD-2-Clause' 'BSD-3-Clause')
+provides=('gamescope')
+conflicts=('gamescope')
+
+depends=(
+    'glibc'
+    'lcms2'
+    'libavif'
+    'libcap'
+    'libdecor'
+    'libdrm'
+    'libei'
+    'libinput'
+    'libpipewire'
+    'libx11'
+    'libxcb'
+    'libxcomposite'
+    'libxcursor'
+    'libxdamage'
+    'libxext'
+    'libxfixes'
+    'libxi'
+    'libxkbcommon'
+    'libxmu'
+    'libxrender'
+    'libxres'
+    'libxtst'
+    'libxxf86vm'
+    'luajit'
+    'pixman'
+    'sdl2'
+    'seatd'
+    'vulkan-icd-loader'
+    'wayland'
+    'xcb-util-errors'
+    'xcb-util-wm'
+    'xorg-server-xwayland'
+)
+
+makedepends=(
+    'git'
+    'meson'
+    'ninja'
+    'cmake'
+    'glslang'
+    'pkgconf'
+    'wayland-protocols'
+    'vulkan-headers'
+    'xorgproto'
+    'hwdata'
+    'stb'
+    'benchmark'
+    'glm'
+)
+
+source=("gamescope::git+https://github.com/MasterGenotype/gamescope.git#branch=gamescope-ba")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd gamescope
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+    cd gamescope
+    git submodule update --init --recursive
+}
+
+build() {
+    cd gamescope
+    meson setup build \
+        --prefix=/usr \
+        --buildtype=release \
+        -Dpipewire=enabled \
+        -Drt_cap=enabled \
+        -Ddrm_backend=enabled \
+        -Dsdl2_backend=enabled \
+        -Denable_gamescope=true \
+        -Denable_gamescope_wsi_layer=true \
+        -Denable_openvr_support=false \
+        -Dbenchmark=disabled \
+        -Dwlroots:xwayland=enabled \
+        -Dwlroots:renderers='vulkan','gles2' \
+        -Dwlroots:backends='drm','libinput','x11' \
+        -Dwlroots:session=enabled \
+        -Dwlroots:color-management=enabled \
+        -Dwlroots:libliftoff=enabled \
+        -Dc_args=-Wno-error \
+        -Dcpp_args=-Wno-error
+    ninja -C build
+}
+
+package() {
+    cd gamescope
+    meson install -C build --destdir="$pkgdir" --skip-subprojects
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/src/resources/gamescope_update/deploytix-gamescope-guard.hook
+++ b/src/resources/gamescope_update/deploytix-gamescope-guard.hook
@@ -1,0 +1,17 @@
+# Abort any gamescope install/upgrade that was not initiated by
+# deploytix-update-gamescope.  The AUR gamescope (upstream Valve source,
+# different meson options) breaks the Steam gamescope session on Deploytix
+# systems, so gamescope may only be replaced by the canonical rebuild.
+
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = gamescope
+Target = gamescope-git
+
+[Action]
+Description = Checking gamescope update source (Deploytix guard)...
+When = PreTransaction
+Exec = /usr/share/deploytix/gamescope/gamescope-guard.sh
+AbortOnFail

--- a/src/resources/gamescope_update/deploytix-update-gamescope.desktop
+++ b/src/resources/gamescope_update/deploytix-update-gamescope.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Update Gamescope
+GenericName=Gamescope Updater
+Comment=Rebuild and update gamescope (Bazzite fork) with the exact Deploytix build configuration
+Exec=deploytix-update-gamescope
+Icon=system-software-update
+Terminal=true
+Categories=System;Settings;PackageManager;
+Keywords=gamescope;steam;gamemode;update;rebuild;deploytix;

--- a/src/resources/gamescope_update/deploytix-update-gamescope.sh
+++ b/src/resources/gamescope_update/deploytix-update-gamescope.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# deploytix-update-gamescope — rebuild and update the Deploytix gamescope
+#
+# gamescope on Deploytix systems is the Bazzite-maintained fork built with
+# a specific set of meson options (see /usr/share/deploytix/gamescope/PKGBUILD).
+# Updating it through the AUR replaces it with the upstream Valve build,
+# compiled with different options, which breaks the Steam gamescope session
+# (Steam fails to launch in game mode).
+#
+# This tool rebuilds gamescope from the same fork/branch with the exact
+# same PKGBUILD — and therefore the exact same meson options — every time.
+# It is the only supported way to update gamescope on a Deploytix system:
+# a pacman PreTransaction hook (deploytix-gamescope-guard) aborts any
+# gamescope install/upgrade not initiated by this script.
+#
+# Usage:
+#   deploytix-update-gamescope [--check] [--force]
+#
+#   --check   Only report whether an update is available (exit 0 = update
+#             available, exit 10 = already up to date), do not build.
+#   --force   Rebuild and reinstall even if already at the latest commit.
+
+set -euo pipefail
+
+PKGNAME="gamescope-git"
+PKGBUILD_SRC="/usr/share/deploytix/gamescope/PKGBUILD"
+GUARD_FLAG="/run/deploytix/gamescope-update-in-progress"
+BUILD_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/deploytix/gamescope-update"
+REMOTE="https://github.com/MasterGenotype/gamescope.git"
+BRANCH="gamescope-ba"
+
+msg()  { printf '\033[1;34m==>\033[0m \033[1m%s\033[0m\n' "$*"; }
+msg2() { printf '  \033[1;32m->\033[0m %s\n' "$*"; }
+err()  { printf '\033[1;31m==> ERROR:\033[0m %s\n' "$*" >&2; }
+
+usage() {
+    cat <<'EOF'
+Usage: deploytix-update-gamescope [--check] [--force]
+
+Rebuilds gamescope (Bazzite fork) from the Deploytix source branch with the
+exact same meson options used at install time, then installs it via pacman.
+Do NOT update gamescope through the AUR — that build breaks the Steam
+gamescope session.
+
+Options:
+  --check   Only report whether an update is available (exit 0 = update
+            available, exit 10 = already up to date); do not build.
+  --force   Rebuild and reinstall even if already at the latest commit.
+  --help    Show this help.
+EOF
+}
+
+CHECK_ONLY=0
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --check) CHECK_ONLY=1 ;;
+        --force) FORCE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) err "unknown option: $arg"; usage >&2; exit 2 ;;
+    esac
+done
+
+if [[ $EUID -eq 0 ]]; then
+    err "run as a regular user — makepkg refuses to run as root."
+    err "sudo is invoked internally for dependency sync and package install."
+    exit 1
+fi
+
+if [[ ! -r "$PKGBUILD_SRC" ]]; then
+    err "canonical PKGBUILD not found at $PKGBUILD_SRC"
+    err "this system does not appear to be a Deploytix gaming deployment."
+    exit 1
+fi
+
+# git is needed for the remote check and by makepkg to fetch sources.
+if ! command -v git >/dev/null; then
+    msg "git is not installed; installing it (sudo)..."
+    sudo pacman -S --needed --noconfirm git
+fi
+
+# ── Check whether the remote branch has moved past the installed build ───────
+installed_ver="$(pacman -Q "$PKGNAME" 2>/dev/null | awk '{print $2}' || true)"
+if [[ -n "$installed_ver" ]]; then
+    msg2 "Installed: $PKGNAME $installed_ver"
+else
+    msg2 "$PKGNAME is not currently installed"
+fi
+
+msg "Checking $REMOTE ($BRANCH)..."
+remote_full="$(git ls-remote "$REMOTE" "refs/heads/$BRANCH" | awk '{print $1}')"
+if [[ -z "$remote_full" ]]; then
+    err "could not resolve branch '$BRANCH' on $REMOTE (network down?)"
+    exit 1
+fi
+remote_short="${remote_full:0:7}"
+msg2 "Remote HEAD: $remote_short"
+
+# pkgver format is r<count>.<shorthash> (see PKGBUILD), so the installed
+# version string contains the short commit hash of the built source.
+up_to_date=0
+if [[ -n "$installed_ver" && "$installed_ver" == *".${remote_short}-"* ]]; then
+    up_to_date=1
+fi
+
+if (( CHECK_ONLY )); then
+    if (( up_to_date )); then
+        msg "gamescope is up to date ($installed_ver)"
+        exit 10
+    fi
+    msg "gamescope update available (remote: $remote_short)"
+    exit 0
+fi
+
+if (( up_to_date )) && ! (( FORCE )); then
+    msg "gamescope is already built from the latest commit ($remote_short); nothing to do."
+    msg2 "Use --force to rebuild anyway."
+    exit 0
+fi
+
+# ── Build with the canonical PKGBUILD (exact same meson options) ─────────────
+msg "Rebuilding gamescope from $BRANCH with the Deploytix build configuration..."
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cp "$PKGBUILD_SRC" "$BUILD_DIR/PKGBUILD"
+cd "$BUILD_DIR"
+
+# base-devel is assumed present by makepkg (AUR convention) but is not
+# guaranteed on every deployment; --needed makes this a no-op when it is.
+msg2 "Ensuring build prerequisites (base-devel)..."
+sudo pacman -S --needed --noconfirm base-devel
+
+# --syncdeps pulls makedepends via sudo pacman; --cleanbuild guarantees a
+# pristine srcdir so stale build artifacts can never leak into the package.
+makepkg --syncdeps --force --cleanbuild --noconfirm
+
+# BUILD_DIR was wiped above, so any package here is from this run.  Exclude
+# split debug packages in case makepkg.conf has OPTIONS=(debug).
+pkgfile="$(find "$BUILD_DIR" -maxdepth 1 -name "${PKGNAME}-*.pkg.tar.*" \
+           ! -name "*-debug-*" | head -n1)"
+if [[ -z "$pkgfile" ]]; then
+    err "makepkg completed but no ${PKGNAME} package was produced in $BUILD_DIR"
+    exit 1
+fi
+
+# ── Install — raise the guard flag so the pacman hook lets this through ──────
+msg "Installing $(basename "$pkgfile")..."
+sudo mkdir -p "$(dirname "$GUARD_FLAG")"
+sudo touch "$GUARD_FLAG"
+rc=0
+sudo pacman -U --noconfirm "$pkgfile" || rc=$?
+sudo rm -f "$GUARD_FLAG"
+if (( rc != 0 )); then
+    err "pacman -U failed (exit $rc); the previous gamescope remains installed."
+    exit "$rc"
+fi
+
+rm -rf "$BUILD_DIR"
+msg "gamescope updated successfully: $(pacman -Q "$PKGNAME")"
+msg2 "Restart the gamescope session (or reboot) to pick up the new build."

--- a/src/resources/gamescope_update/deploytix-update-gamescope.sh
+++ b/src/resources/gamescope_update/deploytix-update-gamescope.sh
@@ -144,12 +144,23 @@ if [[ -z "$pkgfile" ]]; then
 fi
 
 # ── Install — raise the guard flag so the pacman hook lets this through ──────
+# The flag must never outlive this script: if it lingered (e.g. Ctrl-C while
+# pacman -U is waiting or running), the guard hook would wave through the AUR
+# gamescope installs it exists to block.  The EXIT trap removes it on every
+# exit path; the INT/TERM traps convert those signals into an exit so the
+# EXIT trap is guaranteed to run.  (/run is tmpfs, so even an unkillable
+# SIGKILL leaves the flag behind only until reboot.)
+remove_guard_flag() { sudo rm -f "$GUARD_FLAG"; }
 msg "Installing $(basename "$pkgfile")..."
 sudo mkdir -p "$(dirname "$GUARD_FLAG")"
+trap remove_guard_flag EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 sudo touch "$GUARD_FLAG"
 rc=0
 sudo pacman -U --noconfirm "$pkgfile" || rc=$?
-sudo rm -f "$GUARD_FLAG"
+remove_guard_flag
+trap - EXIT INT TERM
 if (( rc != 0 )); then
     err "pacman -U failed (exit $rc); the previous gamescope remains installed."
     exit "$rc"

--- a/src/resources/gamescope_update/gamescope-guard.sh
+++ b/src/resources/gamescope_update/gamescope-guard.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# PreTransaction pacman hook body (deploytix-gamescope-guard.hook).
+#
+# Lets a gamescope install/upgrade proceed only when it was initiated by
+# deploytix-update-gamescope, which raises the flag file below around its
+# `pacman -U` call.  Anything else — `yay -Syu`, `yay -S gamescope-git`,
+# a manual `pacman -U` of an AUR-built package — is aborted: those builds
+# use the upstream Valve source and different meson options, and break the
+# Steam gamescope session on Deploytix systems.
+
+if [[ -e /run/deploytix/gamescope-update-in-progress ]]; then
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+:: gamescope on this system is a Deploytix-managed build (Bazzite fork,
+   custom meson options). Replacing it with an AUR or repo build breaks
+   the Steam gamescope session (Steam fails to launch in game mode).
+
+   To update gamescope, run:
+
+       deploytix-update-gamescope
+
+   or use the "Update Gamescope" entry in the application menu.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

Adds a dedicated gamescope update utility (`deploytix-update-gamescope`) to gaming deployments. This ensures gamescope is rebuilt from the Bazzite-maintained fork with the exact same meson options used at install time, preventing breakage from AUR updates that use the upstream Valve source with different build configuration.

## Key Changes

- **Update script** (`deploytix-update-gamescope`): Bash utility that:
  - Checks if a newer commit is available on the `gamescope-ba` branch
  - Rebuilds gamescope from the canonical PKGBUILD with identical meson options
  - Installs via `pacman -U` with a guard flag to bypass the PreTransaction hook
  - Supports `--check` (report-only) and `--force` (rebuild even if up-to-date) modes

- **Canonical PKGBUILD**: Deployed to `/usr/share/deploytix/gamescope/PKGBUILD` and kept in sync with the ISO build copy. Uses the Bazzite fork (`github.com/MasterGenotype/gamescope`, `gamescope-ba` branch) with specific meson options for pipewire, RT capabilities, DRM/SDL2 backends, and wlroots configuration.

- **PreTransaction hook** (`deploytix-gamescope-guard.hook` + `gamescope-guard.sh`): Blocks any gamescope install/upgrade not initiated by the update utility, preventing accidental replacement with incompatible AUR/repo builds.

- **Desktop entry**: Allows launching the update from the application menu.

- **pacman.conf integration**: Adds `IgnorePkg = gamescope-git` to prevent routine system upgrades from attempting to replace the custom build.

- **Installer integration**: New `setup_gamescope_update()` function in `src/configure/gamescope_update.rs` deploys all files during the installation pipeline (Phase 5.22, after gaming packages).

## Implementation Details

- All resources (script, PKGBUILD, hook, desktop entry) are embedded in the binary via `include_str!()` macros
- Files are deployed with appropriate permissions (0o755 for executables, 0o644 for configs)
- Deployment is conditional on `install_gaming` being enabled
- Dry-run mode is fully supported
- The update script runs as a regular user (makepkg requirement) but uses `sudo` internally for dependency sync and package installation

https://claude.ai/code/session_01PTzvPAiRNpq3kCEf3Euzvg