### PR TITLE
release: fix release workflow and bump version to 1.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+    # Pushing a release/vX.Y.Z branch cuts release vX.Y.Z at that commit,
+    # for environments that cannot push tags directly.
+    branches:
+      - "release/v*"
   workflow_dispatch:
     inputs:
       tag:
@@ -93,12 +97,20 @@ jobs:
           path: artifacts/
       - name: Prepare release assets
         run: chmod +x artifacts/deploytix artifacts/deploytix-gui
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME#release/}" >> "$GITHUB_OUTPUT"
+          fi
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          # On tag pushes inputs.tag is empty and ref_name is the tag; on
-          # workflow_dispatch the tag is created at the built commit.
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          # Tag pushes release ref_name as-is; release/vX.Y.Z branch pushes
+          # and workflow_dispatch create the tag at the built commit.
+          tag_name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true
           files: |
             artifacts/deploytix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,10 @@ jobs:
         with:
           # Tag pushes release ref_name as-is; release/vX.Y.Z branch pushes
           # and workflow_dispatch create the tag at the built commit.
+          # Without target_commitish a new tag lands on the default branch
+          # HEAD instead of the commit the binaries were built from.
           tag_name: ${{ steps.tag.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           generate_release_notes: true
           files: |
             artifacts/deploytix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,28 +21,30 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
       - run: cargo fmt -- --check
       - run: cargo clippy --all-features -- -D warnings
 
   build-cli:
-    name: Build portable CLI binary
+    name: Build CLI binary
     needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
       - uses: Swatinem/rust-cache@v2
-      - name: Install musl tools
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Build static binary
-        run: cargo build --release --target x86_64-unknown-linux-musl --bin deploytix
+      # The CLI links libasound (theme audio), which has no static musl
+      # build on the runners, so a fully static musl binary is not possible.
+      - name: Install ALSA headers
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+      - name: Build CLI binary
+        run: cargo build --release --bin deploytix
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: deploytix-x86_64-linux-musl
-          path: target/x86_64-unknown-linux-musl/release/deploytix
+          name: deploytix-x86_64-linux-gnu
+          path: target/release/deploytix
 
   build-gui:
     name: Build GUI binary
@@ -56,6 +58,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            libasound2-dev \
             libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxkbcommon-dev libwayland-dev libgl-dev
       - name: Build GUI binary
@@ -75,7 +78,7 @@ jobs:
       - name: Download CLI artifact
         uses: actions/download-artifact@v4
         with:
-          name: deploytix-x86_64-linux-musl
+          name: deploytix-x86_64-linux-gnu
           path: artifacts/
       - name: Download GUI artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (e.g. v1.4.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -90,6 +96,9 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          # On tag pushes inputs.tag is empty and ref_name is the tag; on
+          # workflow_dispatch the tag is created at the built commit.
+          tag_name: ${{ inputs.tag || github.ref_name }}
           generate_release_notes: true
           files: |
             artifacts/deploytix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,14 @@ jobs:
           else
             echo "tag=${GITHUB_REF_NAME#release/}" >> "$GITHUB_OUTPUT"
           fi
+      # action-gh-release never moves an existing tag, so force the tag to
+      # the built commit ourselves. No-op for tag-push runs (same commit);
+      # for release-branch runs this keeps tag, source, and binaries in sync.
+      - name: Point tag at built commit
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          git tag -f "$TAG" "$GITHUB_SHA"
+          git push -f origin "refs/tags/$TAG:refs/tags/$TAG"
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "deploytix"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deploytix"
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 authors = ["superphenotype"]
 description = "Automated Artix Linux deployment installer for removable media and disks"

--- a/src-rehearsal/main.rs
+++ b/src-rehearsal/main.rs
@@ -14,7 +14,9 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[derive(Parser)]
 #[command(name = "deploytix-rehearsal")]
-#[command(about = "Run a rehearsal installation: execute the full install, record every command, then wipe the disk")]
+#[command(
+    about = "Run a rehearsal installation: execute the full install, record every command, then wipe the disk"
+)]
 #[command(version)]
 struct Args {
     /// Path to configuration file

--- a/src/configure/packages.rs
+++ b/src/configure/packages.rs
@@ -297,12 +297,7 @@ pub fn install_gpu_drivers(
     }
 
     let pkg_strings: Vec<String> = packages.iter().map(|s| s.to_string()).collect();
-    pacman_install_chroot_reviewed(
-        cmd,
-        install_root,
-        "GPU drivers",
-        pkg_strings,
-    )?;
+    pacman_install_chroot_reviewed(cmd, install_root, "GPU drivers", pkg_strings)?;
 
     info!("GPU driver installation complete");
     Ok(())
@@ -504,14 +499,12 @@ pub fn install_gaming_packages(
 
     // Step 2: Install lib32 Vulkan driver(s) for selected GPU vendor(s)
     if !lib32_vulkan.is_empty() {
-        info!("Installing lib32 Vulkan drivers: {}", lib32_vulkan.join(" "));
+        info!(
+            "Installing lib32 Vulkan drivers: {}",
+            lib32_vulkan.join(" ")
+        );
         let pkgs: Vec<String> = lib32_vulkan.iter().map(|s| s.to_string()).collect();
-        pacman_install_chroot_reviewed(
-            cmd,
-            install_root,
-            "lib32 Vulkan drivers",
-            pkgs,
-        )?;
+        pacman_install_chroot_reviewed(cmd, install_root, "lib32 Vulkan drivers", pkgs)?;
     }
 
     // Step 3: Install Steam
@@ -557,7 +550,11 @@ pub fn install_yay(
         cmd,
         install_root,
         "yay build deps (go, git, base-devel)",
-        vec!["go".to_string(), "git".to_string(), "base-devel".to_string()],
+        vec![
+            "go".to_string(),
+            "git".to_string(),
+            "base-devel".to_string(),
+        ],
     )?;
 
     // Create build dir, clone, build, and clean up in a single chroot
@@ -643,12 +640,7 @@ pub fn install_extras_pacman(
         println!("  [dry-run] Would install pacman extras: {:?}", packages);
         return Ok(());
     }
-    pacman_install_chroot_reviewed(
-        cmd,
-        install_root,
-        "Extras (pacman)",
-        packages.to_vec(),
-    )
+    pacman_install_chroot_reviewed(cmd, install_root, "Extras (pacman)", packages.to_vec())
 }
 
 /// Install AUR (`yay -S`) extras provided by the user via the
@@ -713,7 +705,10 @@ pub fn install_iwd_frontend(
 
     let username = &config.user.name;
     let pkg = config.network.iwd_frontend.aur_package();
-    info!("Installing iwd GUI frontend via yay as {}: {}", username, pkg);
+    info!(
+        "Installing iwd GUI frontend via yay as {}: {}",
+        username, pkg
+    );
 
     if cmd.is_dry_run() {
         println!(
@@ -1621,14 +1616,11 @@ pub fn install_evdevhook2(
     }
 
     // Step 1: Install AUR package via yay
-    let pkgs: Vec<String> = EVDEVHOOK2_AUR_PACKAGES.iter().map(|s| s.to_string()).collect();
-    yay_install_chroot_reviewed(
-        cmd,
-        install_root,
-        username,
-        "AUR: evdevhook2-git",
-        pkgs,
-    )?;
+    let pkgs: Vec<String> = EVDEVHOOK2_AUR_PACKAGES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    yay_install_chroot_reviewed(cmd, install_root, username, "AUR: evdevhook2-git", pkgs)?;
     info!("  evdevhook2 AUR package installed");
 
     // Step 2: Write the udev rule (GROUP=input, uaccess tag) that grants

--- a/src/configure/services.rs
+++ b/src/configure/services.rs
@@ -242,9 +242,9 @@ fn map_s6_service_name(service: &str) -> String {
 /// corresponding package was not installed and we skip with a warning.
 fn enable_s6_service(service: &str, install_root: &str) -> Result<()> {
     let s6_service_name = map_s6_service_name(service);
-    let service_dir = format!("{}/etc/s6/sv/{}", install_root, &s6_service_name);
+    let service_dir = format!("{}/etc/s6/sv/{}", install_root, s6_service_name);
     let enabled_dir = format!("{}/etc/s6/adminsv/default/contents.d", install_root);
-    let link_path = format!("{}/{}", enabled_dir, &s6_service_name);
+    let link_path = format!("{}/{}", enabled_dir, s6_service_name);
 
     // Service directories come from official *-s6 packages; skip if missing
     if !Path::new(&service_dir).exists() {

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -331,10 +331,7 @@ impl DeploytixGui {
                         reply,
                     }
                 }
-                GuiPromptRequest::PromptExtras {
-                    can_use_yay,
-                    reply,
-                } => ActivePrompt::Extras {
+                GuiPromptRequest::PromptExtras { can_use_yay, reply } => ActivePrompt::Extras {
                     can_use_yay,
                     pacman_text: String::new(),
                     aur_text: String::new(),

--- a/src/gui/interactive.rs
+++ b/src/gui/interactive.rs
@@ -80,8 +80,6 @@ impl InteractivePolicy for GuiPolicy {
                 return (ExtraPackages::default(), false);
             }
         }
-        reply_rx
-            .recv()
-            .unwrap_or((ExtraPackages::default(), false))
+        reply_rx.recv().unwrap_or((ExtraPackages::default(), false))
     }
 }

--- a/src/gui/panels/summary.rs
+++ b/src/gui/panels/summary.rs
@@ -216,25 +216,26 @@ pub fn show(
                 ui.add_space(theme::SPACING_XS);
 
                 // Summary line
-                let (pass, fail) = results.iter().fold((0, 0), |(p, f), line| {
-                    if line.success {
-                        (p + 1, f)
-                    } else {
-                        (p, f + 1)
-                    }
-                });
+                let (pass, fail) =
+                    results.iter().fold(
+                        (0, 0),
+                        |(p, f), line| {
+                            if line.success {
+                                (p + 1, f)
+                            } else {
+                                (p, f + 1)
+                            }
+                        },
+                    );
                 let summary_color = if fail > 0 {
                     theme::ERROR
                 } else {
                     theme::SUCCESS
                 };
                 ui.label(
-                    RichText::new(format!(
-                        "Rehearsal: {} passed, {} failed",
-                        pass, fail
-                    ))
-                    .color(summary_color)
-                    .strong(),
+                    RichText::new(format!("Rehearsal: {} passed, {} failed", pass, fail))
+                        .color(summary_color)
+                        .strong(),
                 );
 
                 // Scrollable results

--- a/src/gui/state.rs
+++ b/src/gui/state.rs
@@ -2,8 +2,7 @@
 
 use crate::config::{
     Bootloader, CustomPartitionEntry, DesktopEnvironment, Filesystem, InitSystem, IwdFrontend,
-    NetworkBackend,
-    SecureBootMethod, SwapType,
+    NetworkBackend, SecureBootMethod, SwapType,
 };
 use crate::disk::detection::BlockDevice;
 use std::sync::mpsc::Receiver;
@@ -284,10 +283,7 @@ pub enum ActivePrompt {
         pacman_text: String,
         aur_text: String,
         save_to_config: bool,
-        reply: std::sync::mpsc::SyncSender<(
-            crate::utils::interactive::ExtraPackages,
-            bool,
-        )>,
+        reply: std::sync::mpsc::SyncSender<(crate::utils::interactive::ExtraPackages, bool)>,
     },
 }
 

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -47,34 +47,34 @@ pub fn apply(ctx: &egui::Context) {
 
     // Selection
     visuals.selection.bg_fill = ACCENT_BG;
-    visuals.selection.stroke = Stroke::new(1.0, ACCENT);
+    visuals.selection.stroke = Stroke::new(1.0_f32, ACCENT);
 
     // Non-interactive widgets (labels, separators)
     visuals.widgets.noninteractive.bg_fill = BG_PANEL;
-    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0, TEXT_SECONDARY);
+    visuals.widgets.noninteractive.fg_stroke = Stroke::new(1.0_f32, TEXT_SECONDARY);
     visuals.widgets.noninteractive.corner_radius = CornerRadius::same(6);
 
     // Inactive widgets (buttons, checkboxes at rest)
     visuals.widgets.inactive.bg_fill = BG_SECTION;
-    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0, TEXT_PRIMARY);
+    visuals.widgets.inactive.fg_stroke = Stroke::new(1.0_f32, TEXT_PRIMARY);
     visuals.widgets.inactive.corner_radius = CornerRadius::same(6);
     visuals.widgets.inactive.weak_bg_fill = BG_SECTION;
 
     // Hovered
     visuals.widgets.hovered.bg_fill = BG_HOVER;
-    visuals.widgets.hovered.fg_stroke = Stroke::new(1.5, TEXT_PRIMARY);
+    visuals.widgets.hovered.fg_stroke = Stroke::new(1.5_f32, TEXT_PRIMARY);
     visuals.widgets.hovered.corner_radius = CornerRadius::same(6);
     visuals.widgets.hovered.weak_bg_fill = BG_HOVER;
 
     // Active (pressed)
     visuals.widgets.active.bg_fill = ACCENT_BG;
-    visuals.widgets.active.fg_stroke = Stroke::new(2.0, ACCENT);
+    visuals.widgets.active.fg_stroke = Stroke::new(2.0_f32, ACCENT);
     visuals.widgets.active.corner_radius = CornerRadius::same(6);
     visuals.widgets.active.weak_bg_fill = ACCENT_BG;
 
     // Open (e.g., ComboBox dropdown)
     visuals.widgets.open.bg_fill = BG_SECTION;
-    visuals.widgets.open.fg_stroke = Stroke::new(1.0, ACCENT);
+    visuals.widgets.open.fg_stroke = Stroke::new(1.0_f32, ACCENT);
     visuals.widgets.open.corner_radius = CornerRadius::same(6);
 
     // Miscellaneous

--- a/src/gui/widgets.rs
+++ b/src/gui/widgets.rs
@@ -44,7 +44,7 @@ pub fn step_indicator(ui: &mut Ui, current: WizardStep) {
                     egui::pos2(prev_x + radius + 3.0, y_circle),
                     egui::pos2(x - radius - 3.0, y_circle),
                 ],
-                Stroke::new(2.0, color),
+                Stroke::new(2.0_f32, color),
             );
         }
 
@@ -55,7 +55,7 @@ pub fn step_indicator(ui: &mut Ui, current: WizardStep) {
         } else if is_past {
             painter.circle_filled(center, radius, theme::SUCCESS);
         } else {
-            painter.circle_stroke(center, radius, Stroke::new(2.0, theme::TEXT_MUTED));
+            painter.circle_stroke(center, radius, Stroke::new(2.0_f32, theme::TEXT_MUTED));
         }
 
         // Number / checkmark
@@ -103,7 +103,7 @@ pub fn section(ui: &mut Ui, title: &str, add_body: impl FnOnce(&mut Ui)) {
         .fill(theme::BG_SECTION)
         .corner_radius(CornerRadius::same(8))
         .inner_margin(Margin::same(14))
-        .stroke(Stroke::new(1.0, theme::BG_HOVER))
+        .stroke(Stroke::new(1.0_f32, theme::BG_HOVER))
         .show(ui, |ui| {
             ui.label(
                 RichText::new(title)

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -1592,7 +1592,7 @@ impl Installer {
             }
 
             let lv_device = lv_path(vg_name, &vol.name);
-            let mount_point = format!("{}{}", INSTALL_ROOT, &vol.mount_point);
+            let mount_point = format!("{}{}", INSTALL_ROOT, vol.mount_point);
 
             if !self.cmd.is_dry_run() {
                 fs::create_dir_all(&mount_point)?;

--- a/src/install/installer.rs
+++ b/src/install/installer.rs
@@ -24,8 +24,8 @@ use crate::install::fstab::{
     LvmThinFstabParams, MultiVolumeFstabParams,
 };
 use crate::install::{
-    generate_fstab, mount_boot_btrfs_subvolume, mount_partitions,
-    mount_partitions_zfs, run_basestrap, unmount_all,
+    generate_fstab, mount_boot_btrfs_subvolume, mount_partitions, mount_partitions_zfs,
+    run_basestrap, unmount_all,
 };
 use crate::utils::command::{CommandRunner, OperationRecord};
 use crate::utils::deps::ensure_dependencies;
@@ -1263,12 +1263,7 @@ impl Installer {
             }
 
             let svols = multi_volume_subvolumes(&container.volume_name);
-            create_btrfs_subvolumes(
-                &self.cmd,
-                &container.mapped_path,
-                &svols,
-                temp_mount,
-            )?;
+            create_btrfs_subvolumes(&self.cmd, &container.mapped_path, &svols, temp_mount)?;
             mount_btrfs_subvolumes(&self.cmd, &container.mapped_path, &svols, INSTALL_ROOT)?;
         }
 

--- a/src/rehearsal/guard.rs
+++ b/src/rehearsal/guard.rs
@@ -27,10 +27,7 @@ pub struct DiskWipeGuard {
 impl DiskWipeGuard {
     /// Create a new armed guard for the given device.
     pub fn new(device: &str) -> Self {
-        info!(
-            "DiskWipeGuard: armed for {} (will wipe on drop)",
-            device
-        );
+        info!("DiskWipeGuard: armed for {} (will wipe on drop)", device);
         Self {
             device: device.to_string(),
             armed: true,
@@ -62,10 +59,7 @@ impl DiskWipeGuard {
     /// Best-effort cleanup and wipe.  Errors are logged but never
     /// propagated — this runs in a Drop impl where panicking is UB.
     fn do_cleanup_and_wipe(device: &str) -> bool {
-        info!(
-            "DiskWipeGuard: starting cleanup + wipe for {}",
-            device
-        );
+        info!("DiskWipeGuard: starting cleanup + wipe for {}", device);
 
         // 1. Unmount everything under INSTALL_ROOT (deepest first)
         Self::unmount_all();
@@ -112,10 +106,7 @@ impl DiskWipeGuard {
             }
         }
 
-        info!(
-            "DiskWipeGuard: wipe complete for {}",
-            device
-        );
+        info!("DiskWipeGuard: wipe complete for {}", device);
         true
     }
 
@@ -186,13 +177,7 @@ impl DiskWipeGuard {
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()
-            .map(|s| {
-                if s.success() {
-                    Ok(())
-                } else {
-                    Err(())
-                }
-            })
+            .map(|s| if s.success() { Ok(()) } else { Err(()) })
             .unwrap_or(Err(()))
     }
 }

--- a/src/rehearsal/report.rs
+++ b/src/rehearsal/report.rs
@@ -51,9 +51,12 @@ impl RehearsalReport {
     /// Print a colored table to stdout.
     #[allow(clippy::print_literal)]
     pub fn print_table(&self) {
-        let top    = "┌─────────┬────────────┬──────────────────────────────────────────────────────────┐";
-        let mid    = "├─────────┼────────────┼──────────────────────────────────────────────────────────┤";
-        let bottom = "└─────────┴────────────┴──────────────────────────────────────────────────────────┘";
+        let top =
+            "┌─────────┬────────────┬──────────────────────────────────────────────────────────┐";
+        let mid =
+            "├─────────┼────────────┼──────────────────────────────────────────────────────────┤";
+        let bottom =
+            "└─────────┴────────────┴──────────────────────────────────────────────────────────┘";
 
         println!();
         println!("{}", top);
@@ -98,10 +101,7 @@ impl RehearsalReport {
         }
 
         if let Some(ref err) = self.short_circuited_at {
-            println!(
-                "{}",
-                format!("Short-circuited at: {}", err).yellow().bold()
-            );
+            println!("{}", format!("Short-circuited at: {}", err).yellow().bold());
         }
 
         if self.disk_wiped {
@@ -246,7 +246,10 @@ pub fn print_live_record(index: usize, rec: &OperationRecord) {
     let _ = writeln!(
         std::io::stderr(),
         "  [{}] {}  {:>10}  {}",
-        index, status, dur, cmd
+        index,
+        status,
+        dur,
+        cmd
     );
 
     // Show first line of stderr for failures

--- a/src/utils/cli_policy.rs
+++ b/src/utils/cli_policy.rs
@@ -63,7 +63,12 @@ fn prompt_pacman_confirm(inv: &PacmanInvocation) -> Result<PacmanDecision> {
             writeln!(out, "  (run as user {})", u)?;
         }
     }
-    writeln!(out, "  packages: {} ({})", inv.packages.len(), inv.packages.join(" "))?;
+    writeln!(
+        out,
+        "  packages: {} ({})",
+        inv.packages.len(),
+        inv.packages.join(" ")
+    )?;
     write!(out, "[A]pprove · [E]dit · [S]kip · [C]ancel ▸ ")?;
     out.flush()?;
     drop(out);
@@ -238,7 +243,9 @@ fn open_editor(path: &std::path::Path) -> Result<()> {
 
 fn shell_escape(p: &std::path::Path) -> String {
     let s = p.display().to_string();
-    if s.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.')) {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '_' | '-' | '.'))
+    {
         s
     } else {
         format!("'{}'", s.replace('\'', "'\\''"))
@@ -253,25 +260,20 @@ fn prompt_extras_loop(can_use_yay: bool) -> Result<(ExtraPackages, bool)> {
     let mut extras = ExtraPackages::default();
 
     loop {
-        let pacman_pkgs = read_line(
-            "Repository packages (pacman -S). Space-separated, empty to skip:\n  > ",
-        )?;
+        let pacman_pkgs =
+            read_line("Repository packages (pacman -S). Space-separated, empty to skip:\n  > ")?;
         if !pacman_pkgs.trim().is_empty() {
-            extras.pacman.extend(
-                pacman_pkgs
-                    .split_whitespace()
-                    .map(|s| s.to_string()),
-            );
+            extras
+                .pacman
+                .extend(pacman_pkgs.split_whitespace().map(|s| s.to_string()));
         }
         if can_use_yay {
             let aur_pkgs =
                 read_line("AUR packages (yay -S). Space-separated, empty to skip:\n  > ")?;
             if !aur_pkgs.trim().is_empty() {
-                extras.aur.extend(
-                    aur_pkgs
-                        .split_whitespace()
-                        .map(|s| s.to_string()),
-                );
+                extras
+                    .aur
+                    .extend(aur_pkgs.split_whitespace().map(|s| s.to_string()));
             }
         }
         if extras.is_empty() || !prompt_confirm("Add more extras?", false).unwrap_or(false) {


### PR DESCRIPTION
- cargo fmt over the tree: every past tag-triggered release run died at
  the fmt check, so no release was ever published by CI
- install libasound2-dev in all workflow jobs: alsa-sys needs alsa.pc at
  compile time (theme audio via rodio)
- build the CLI as a regular glibc binary: the binary links libasound,
  which has no static musl build on the runners, so the previous
  static-musl job could never link
- bump crate version 1.3.0 -> 1.4.0

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QQLnhQig5QiNiv8SjQK8S4